### PR TITLE
Run the contents of /etc/pre-init.d before executing the main command

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,6 +7,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python-jinja2 curl
 RUN curl -Lo /bin/envconsul https://github.com/hashicorp/envconsul/releases/download/v0.2.0/envconsul_linux_amd64 && \
     chmod +x /bin/envconsul
 
+RUN mkdir /etc/pre-init.d
+
 ADD set_ark_host /bin/set_ark_host
 ADD set_ark_hostname /bin/set_ark_hostname
 ADD ship /bin/ship

--- a/base/ship
+++ b/base/ship
@@ -14,6 +14,10 @@ shift || true
 source /bin/set_ark_host # in /etc/hosts
 source /bin/set_ark_hostname
 
+if [ -d /etc/pre-init.d ]; then
+    run-parts -v --exit-on-error /etc/pre-init.d
+fi
+
 if [ -e /etc/ship.d/$COMMAND ]; then
   /etc/ship.d/$COMMAND $@
 else


### PR DESCRIPTION
This change introduces a directory /etc/pre-init.d/, which is processed using run-parts. Scripts in this directory are executed before the main app runs. The intent is to provide a mechanism for images derived from base to hook in to the container initialization process in order to perform any required run-time initialization.

Any example use case for this mechanism is the key management system, which will provide scripts to retrieve and decrypt application specific credentials, etc.