### PR TITLE
A few cleanups, following guidance from https://docs.docker.com/articles/dockerfile_best-practices/

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,20 +1,21 @@
 FROM ubuntu:trusty
-MAINTAINER Anthony Nowell <anthony.nowell@socrata.com.com>
+MAINTAINER Anthony Nowell <anthony.nowell@socrata.com>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get -y dist-upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python-jinja2 curl
+# Add a user so containers can run things as non root.  Not perfect since it is shared across containers,
+# but eventually uid namespacing will hopefully fix that.
+RUN groupadd -r socrata && useradd -r -g socrata socrata
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+  curl \
+  python-jinja2
 
 RUN curl -Lo /bin/envconsul https://github.com/hashicorp/envconsul/releases/download/v0.2.0/envconsul_linux_amd64 && \
     chmod +x /bin/envconsul
 
 RUN mkdir /etc/pre-init.d
 
-ADD set_ark_host /bin/set_ark_host
-ADD set_ark_hostname /bin/set_ark_hostname
-ADD ship /bin/ship
-ADD ship.d /etc/ship.d
-
-ADD env_parse /bin/env_parse
+COPY env_parse set_ark_host set_ark_hostname ship /bin/
+COPY ship.d /etc/ship.d/
 
 ENTRYPOINT ["/bin/ship"]
 CMD ["run"]

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,7 +1,8 @@
 FROM socrata/base
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common
-RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:webupd8team/java && apt-get -y update
-RUN echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections && \
-DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java7-installer
+RUN DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:webupd8team/java && apt-get -y update && \
+  echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+  echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java7-installer && \
+  rm -rf /var/cache/oracle-jdk7-installer


### PR DESCRIPTION
- create socrata user so apps can run as non-root for security reasons.  It isn't ideal that
  it is a shared uid, but the real solution to that is uid namespaces.  Even if each image
  created its own user, that wouldn't avoid uid sharing so may as well do it here.
- keep apt-get update and install in one RUN command to avoid potential caching pitfalls, and minimize
  the number of unnecessary RUN layers.
- Use COPY instead of ADD when you don't need ADD's features, and reduce the number of layers.
- don't leave unnecessary stuff in /var/cache/oracle-jdk7-installer to reduce image size.