### PR TITLE
Clean up apt list cache after apt-get updates

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,8 @@ RUN groupadd -r socrata && useradd -r -g socrata socrata
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
   curl \
-  python-jinja2
+  python-jinja2 && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN curl -Lo /bin/envconsul https://github.com/hashicorp/envconsul/releases/download/v0.2.0/envconsul_linux_amd64 && \
     chmod +x /bin/envconsul

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,8 +1,10 @@
 FROM socrata/base
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
   DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:webupd8team/java && apt-get -y update && \
   echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
   echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java7-installer && \
-  rm -rf /var/cache/oracle-jdk7-installer
+  rm -rf /var/cache/oracle-jdk7-installer && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This seems to be a common practice among Dockerfiles to slim them down the resulting image a
bit.

([for example](https://github.com/docker-library/rails/blob/master/Dockerfile))