### PR TITLE
Raise the ulimit for everyone

### DIFF
--- a/base/ship
+++ b/base/ship
@@ -21,6 +21,9 @@ if [ -d /etc/pre-init.d ]; then
     run-parts -v --exit-on-error /etc/pre-init.d
 fi
 
+# Raise the ulimit - default of 1024 is stone age
+ulimit -n 10000
+
 if [ -e /etc/ship.d/$COMMAND ]; then
   exec /etc/ship.d/$COMMAND $@
 else


### PR DESCRIPTION
The default ulimit of 1024 is stone age and not enough for most server applications.  Let's raise it for everyone.