### PR TITLE
Group Permission inheritence

### DIFF
--- a/base/set_metrics_dir
+++ b/base/set_metrics_dir
@@ -2,4 +2,5 @@ export METRICS_DIR="$METRICS_ROOT_DIR/$HOSTNAME"
 
 mkdir -p $METRICS_DIR
 chown -R socrata:metrics $METRICS_DIR
-chmod -R a+rwx $METRICS_DIR
+chmod -R 774 $METRICS_DIR
+chmod g+s $METRICS_DIR


### PR DESCRIPTION
Files found under the metrics container directory will now inherit from Metrics directory.

- Restricted write and execution permission to container owner and group.