### PR TITLE
Revert "Make creation of metrics dir happen as the socrata user."

### DIFF
--- a/base/set_metrics_dir
+++ b/base/set_metrics_dir
@@ -1,6 +1,6 @@
 export METRICS_DIR="$METRICS_ROOT_DIR/$HOSTNAME"
 
-sudo -u socrata mkdir -p $METRICS_DIR
+mkdir -p $METRICS_DIR
 chown -R socrata:metrics $METRICS_DIR
 chmod -R 774 $METRICS_DIR
 chmod g+s $METRICS_DIR


### PR DESCRIPTION
This reverts commit 6404aa75c96bf21da6aa42ee9f63a836867dbd8e.

Was breaking odysseus build.