### PR TITLE
EN-2758 Fix bug in phantomjs bin path

### DIFF
--- a/frontend-12_04/Dockerfile
+++ b/frontend-12_04/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y libfontconfig1 bzip2 && \
     mkdir -p /usr/local/share/phantomjs && \
     wget https://phantomjs.googlecode.com/files/phantomjs-1.9.1-linux-x86_64.tar.bz2 && \
-    tar xjf phantomjs-1.9.1-linux-x86_64.tar.bz2 -C /usr/local/share/phantomjs && \
+    tar xjf phantomjs-1.9.1-linux-x86_64.tar.bz2 --strip=1 -C /usr/local/share/phantomjs && \
     rm -f phantomjs-1.9.1-linux-x86_64.tar.bz2 && \
-    ln -s /usr/local/share/phantomjs/bin/phantomjs /usr/bin/phantomjs
+    ln -fs /usr/local/share/phantomjs/bin/phantomjs /usr/bin/phantomjs
 
 # Install JDK7 to enable JDK 7 on Ubuntu 12
 # Required to run Jenkins slave process and connect to Jenkins master (running Java7 as well)


### PR DESCRIPTION
This fixes a directory tree issue in the `tar` extraction and forces the creation of the symlink to the `phantomjs` executable.

FYI: @JoeNunnelley, @progman32, @michaelb990

Confirmation:
```sh
/usr/bin/phantomjs --version
1.9.1
```