### PR TITLE
Generate and set locales

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,5 +3,9 @@ FROM socrata/base
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python python-dev python-pip
 
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/python=""

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -2,6 +2,10 @@ FROM socrata/base
 
 RUN apt-get update
 
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
 # remove several traces of debian python
 RUN apt-get purge -y python.*
 


### PR DESCRIPTION
Some Python modules failed to install due to the fact that locale wasn't
being set. This changeset addresses that.