### PR TITLE
Bump spacy and scikit-learn versions

### DIFF
--- a/py3_analysis/Dockerfile
+++ b/py3_analysis/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libblas-
 
 RUN pip install numpy==1.11.0 \
                 scipy==0.17.1 \
-                scikit-learn==0.17
+                scikit-learn==0.17.1
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/py3_analysis=""

--- a/py3_spacy/Dockerfile
+++ b/py3_spacy/Dockerfile
@@ -1,6 +1,6 @@
 FROM socrata/py3_analysis
 
-RUN pip install spacy==0.100 && python -m spacy.en.download
+RUN pip install spacy==0.101 && python -m spacy.en.download
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/py3_spacy=""


### PR DESCRIPTION
Since Clads is the only consumer of these images and local dev uses the latest versions of these dependencies, I bumped the Dockerfiles to match.