### PR TITLE
Build Python3 from source so we can use Python 3.5

### DIFF
--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -18,6 +18,9 @@ RUN curl https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz -o Python-3.5.
   && cd Python-3.5.2 \
   && ./configure && make && make install
 
+# remove installation bits
+RUN rm Python-3.5.2.tgz && rm -r Python-3.5.2
+
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
   && ln -s easy_install-3.5 easy_install \

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -9,15 +9,22 @@ ENV LANG en_US.UTF-8
 # remove several traces of debian python
 RUN apt-get purge -y python.*
 
-RUN apt-get -y install build-essential libssl-dev gfortran gcc g++ python3 python3-dev python3-pip
+# install some basic goodies
+RUN apt-get -y install build-essential libssl-dev gfortran gcc g++
+
+# download python source
+RUN curl https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz -o Python-3.5.2.tgz \
+  && tar -zxf Python-3.5.2.tgz \
+  && cd Python-3.5.2 \
+  && ./configure && make && make install
 
 # make some useful symlinks that are expected to exist
 RUN cd /usr/local/bin \
-  && ln -s /usr/bin/easy_install-3.4 easy_install \
-  && ln -s /usr/bin/pip3 pip \
-  && ln -s /usr/bin/pydoc3 pydoc \
-  && ln -s /usr/bin/python3 python \
-  && ln -s /usr/bin/python-config3 python-config
+  && ln -s easy_install-3.5 easy_install \
+  && ln -s pip3.5 pip \
+  && ln -s pydoc3.5 pydoc \
+  && ln -s python3.5 python \
+  && ln -s python-config3.5 python-config
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/python3=""


### PR DESCRIPTION
The latest stable release of Python (3.5.2) isn't available via
apt. With this change, we install it directly from source.