### PR TITLE
IMPROVEMENT: Create team-specific image with team specific dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Build a single image from this project, with support for specific versions:
 - [`socrata/ruby:2.1`](ruby/2.1): `socrata/base` image with Ruby 2.1 installed.
 - [`socrata/ruby:2.2`](ruby/2.2): `socrata/base` image with Ruby 2.2 installed.
 - [`socrata/ruby:2.3`](ruby/2.3): `socrata/base` image with Ruby 2.3 installed.
+- [`socrata/ruby:2.3-admin`](ruby/2.3-admin): `socrata/base` image with Ruby 2.3 installed and a few dependencies specifically for admin team.
 - [`socrata/runit-ruby`](runit-ruby): Alias for `socrata/runit-ruby:2.3`.
 - [`socrata/runit-ruby:2.2`](runit-ruby/2.2): `socrata/runit` version of `socrata/ruby:2.2`.
 - [`socrata/runit-ruby:2.3`](runit-ruby/2.3): `socrata/runit` version of `socrata/ruby:2.3`.

--- a/ruby/2.3-admin/Dockerfile
+++ b/ruby/2.3-admin/Dockerfile
@@ -1,0 +1,21 @@
+FROM socrata/ruby:2.3
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    build-essential
+    libpq-dev \
+    libsqlite3-dev \
+    libxml2-dev \
+    libxslt-dev \
+    make && \
+  apt-get -y purge \
+    keyboard-configuration \
+    libruby1.9.1 \
+    perl \
+    ruby1.9.1 \
+    ruby2.0 \
+  && rm -rf /var/lib/apt/lists/*
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/ruby2.3-admin=""


### PR DESCRIPTION
Per discussion with Justin, I am moving these package installs out of the base image and into a team-specific docker image that we can share for our projects alone.

Also, experimentally purging some packages which I believe to be unnecessary.