### PR TITLE
FIX: Team-specific image has broken clortho

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,9 +12,6 @@ RUN groupadd -g 31415 metrics && usermod -a -G metrics socrata
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
-    libpq-dev \
-    libsqlite3-dev \
-    make \
     python-jinja2 \
     ruby2.0 \
     zip \

--- a/ruby/2.3-admin/Dockerfile
+++ b/ruby/2.3-admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/ruby:2.3
+FROM socrata/ruby2.3
 MAINTAINER Socrata <sysadmin@socrata.com>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
@@ -8,13 +8,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
     libsqlite3-dev \
     libxml2-dev \
     libxslt-dev \
-    make && \
-  apt-get -y purge \
-    keyboard-configuration \
-    libruby1.9.1 \
-    perl \
-    ruby1.9.1 \
-    ruby2.0 \
+    make \
   && rm -rf /var/lib/apt/lists/*
 
 # LABEL must be last for proper base image discoverability


### PR DESCRIPTION
* Remove experimental purges
* Update to use upstream image with current tag structure
* Remove package installs from base that I thought I did yesterday.