### PR TITLE
Revert "EN-13667: Pin bundler to 1.13.7 until we figure out how to unfuck bundler."

### DIFF
--- a/ruby/2.3/Dockerfile
+++ b/ruby/2.3/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 
 # skip installing gem documentation
 RUN echo 'gem: --no-rdoc --no-ri --no-document' >> "/etc/gemrc" && \
-  gem install bundler -v 1.13.7
+  gem install bundler
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/ruby2.3=""


### PR DESCRIPTION
Reverts socrata/shipyard#75

Figured it out. We're turning on `--enable-shared` on the build machine.