### PR TITLE
Account for new marathon app ids when setting APP_NAME

### DIFF
--- a/runit-java8/set_jmx_hostname
+++ b/runit-java8/set_jmx_hostname
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-APP_NAME=`echo ${MARATHON_APP_ID}|cut -d'/' -f3`
+APP_NAME=`echo ${MARATHON_APP_ID}|cut -d'/' -f2`
 if [ -z ${APP_NAME} ]; then
     APP_NAME=unknown_marathon_app
 fi


### PR DESCRIPTION
* after marathon upgrade, marathon app ids no longer include environment prefixes
* changes which field to grab for setting APP_NAME