### PR TITLE
Set en_US.UTF-8 as default locale

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,9 +35,9 @@ ENV METRICS_ROOT_DIR /data/metrics
 ENTRYPOINT ["/bin/ship"]
 CMD ["run"]
 
-# LABEL must be last for proper base image discoverability
-LABEL repository.socrata/base=""
-
 # Add locale profiles and default to en_US.UTF-8
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/base=""

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,7 +35,7 @@ ENV METRICS_ROOT_DIR /data/metrics
 ENTRYPOINT ["/bin/ship"]
 CMD ["run"]
 
-# Add locale profiles and default to en_US.UTF-8
+# Ensure that containers and apps default to UTF-8
 RUN locale-gen C.UTF-8
 ENV LANG C.UTF-8
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,8 +36,8 @@ ENTRYPOINT ["/bin/ship"]
 CMD ["run"]
 
 # Add locale profiles and default to en_US.UTF-8
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
+RUN locale-gen C.UTF-8
+ENV LANG C.UTF-8
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/base=""

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -37,3 +37,7 @@ CMD ["run"]
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/base=""
+
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8


### PR DESCRIPTION
This seems like the right thing to do to ensure reasonable defaults WRT character sets / encoding in our marathon apps.