### PR TITLE
reworking to enable rbenv installation and adding 2.3.4 and 2.3.5

### DIFF
--- a/ruby/2.3/Dockerfile
+++ b/ruby/2.3/Dockerfile
@@ -5,13 +5,39 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get --force-yes -fuy install software-properties-common && \
   DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:brightbox/ruby-ng && \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y ruby2.3 ruby2.3-dev && \
   DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove software-properties-common && \
   rm -rf /var/lib/apt/lists/*
 
+RUN sudo apt-get update
+RUN sudo apt-get install -y build-essential
+RUN apt-get install -y libssl-dev libreadline-dev zlib1g-dev
+RUN sudo apt-get install -y git
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' > /etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >> /etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >> /etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+ENV RBENV_ROOT /usr/local/rbenv
+
+ENV PATH "$RBENV_ROOT/bin:$RBENV_ROOT/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+RUN rbenv install 2.3.4
+RUN rbenv install 2.3.5
+RUN rbenv global 2.3.5
+
 # skip installing gem documentation
 RUN echo 'gem: --no-rdoc --no-ri --no-document' >> "/etc/gemrc" && \
-  gem install bundler -v 1.13.7
+  gem install bundler
+
+RUN rbenv rehash
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/ruby2.3=""


### PR DESCRIPTION
one option is to enable rbenv installs and install the current and current -1 versions of ruby.  this compiles and installs both 2.3.4 and 2.3.5