### PR TITLE
Revert jq utility from the frontend images.

### DIFF
--- a/jenkins-worker/Dockerfile
+++ b/jenkins-worker/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y \
             git-core \
-            jq \
             openssh-server \
             sudo
 

--- a/rails4-deps/Dockerfile
+++ b/rails4-deps/Dockerfile
@@ -14,7 +14,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update \
     g++ \
     gcc \
     git \
-    jq \
     libsnappy1 \
     libsnappy-dev \
     libxml2-dev \


### PR DESCRIPTION
@rantler reverting what I did on Friday.  Will need to rebuild rails4deps and then rebuild jenkins_frontend-builder image 