### PR TITLE
utf 8 locale initialization for the base docker image used by frontend, etc.

### DIFF
--- a/jenkins-worker/Dockerfile
+++ b/jenkins-worker/Dockerfile
@@ -10,6 +10,14 @@ MAINTAINER Matt Shanker <matthew.shanker@socrata.com>
 RUN echo '*  	hard	    nofile  	525488' >> /etc/security/limits.conf
 RUN echo '*  	soft	    nofile  	525488' >> /etc/security/limits.conf
 
+# Add lines to the locale related files
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+RUN update-locale en_US.UTF-8
+
 # Make sure the package repository is up to date, upgrade out of date packages.
 # Add python-software-properties, which installs the `add-apt-repository` script
 # Enable a new repo for git, the default for Ubuntu 10.04 is way too old

--- a/jenkins-worker/README.md
+++ b/jenkins-worker/README.md
@@ -11,8 +11,8 @@ The later steps are currently specific to the Frontend build. In the future it w
 To apply changes to this Dockerfile to the frontend build worker:
 
 1. Update Dockerfile
-2. `docker build -t registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/jenkins-worker_base:latest`
-3. `docker push registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/jenkins-worker_base:latest`
+2. `docker build -t 649617362025.dkr.ecr.us-west-2.amazonaws.com/internal/jenkins-worker_base:latest`
+3. `docker push 649617362025.dkr.ecr.us-west-2.amazonaws.com/internal/jenkins-worker_base:latest`
 4. SSH into the Jenkins host and pull down the new image: 
-`docker pull registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/jenkins-worker_base:latest`
+`docker pull 649617362025.dkr.ecr.us-west-2.amazonaws.com/internal/jenkins-worker_base:latest`
 5. Manually trigger or wait for scheduled run of the `build-worker_frontend` job


### PR DESCRIPTION
initializing the base docker image to be configured with locale en_US.UTF-8 which is what the project is asking for but not getting. Right now this produces a bunch of warnings in the frontend builds that are very distracting.  Also updated the README with correct ECR locations.