### PR TITLE
locking the rails4-deps to use the ruby:2.3.5 base image

### DIFF
--- a/rails4-deps/Dockerfile
+++ b/rails4-deps/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/ruby2.3
+FROM socrata/ruby:2.3.5
 MAINTAINER Socrata <sysadmin@socrata.com>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update \


### PR DESCRIPTION
converting to use the base image that is locked to 2.3.5 for ruby rather than an image whose ruby version floats.