### PR TITLE
On build, do a dist-upgrade

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,6 +10,7 @@ RUN groupadd -r socrata && useradd -r -g socrata socrata
 RUN groupadd -g 31415 metrics && usermod -a -G metrics socrata
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
     dnsutils \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ RUN groupadd -r socrata && useradd -r -g socrata socrata
 RUN groupadd -g 31415 metrics && usermod -a -G metrics socrata
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
     dnsutils \

--- a/runit/Dockerfile
+++ b/runit/Dockerfile
@@ -10,6 +10,7 @@ RUN groupadd -r socrata && useradd -r -g socrata socrata
 RUN groupadd -g 31415 metrics && usermod -a -G metrics socrata
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
     dnsutils \

--- a/runit/Dockerfile
+++ b/runit/Dockerfile
@@ -10,7 +10,7 @@ RUN groupadd -r socrata && useradd -r -g socrata socrata
 RUN groupadd -g 31415 metrics && usermod -a -G metrics socrata
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
     dnsutils \


### PR DESCRIPTION
In order to meet fedramp requirements, we need to ensure our images are as up-to-date as possible with the provided packages.  

Added one line for `apt-get dist-upgrade -y`.  This should not have an affect on the kernels since the containers utilize the host kernel.

> upgrade
>    upgrade is used to install the newest versions of all packages
>    currently installed on the system from the sources enumerated in
>    /etc/apt/sources.list. Packages currently installed with new
>    versions available are retrieved and upgraded; under no
>    circumstances are currently installed packages removed, or packages
>    not already installed retrieved and installed. New versions of
>    currently installed packages that cannot be upgraded without
>    changing the install status of another package will be left at
>    their current version. An update must be performed first so that
>    apt-get knows that new versions of packages are available.
> 
> dist-upgrade
>    dist-upgrade in addition to performing the function of upgrade,
>    also intelligently handles changing dependencies with new versions
>    of packages; apt-get has a "smart" conflict resolution system, and
>    it will attempt to upgrade the most important packages at the
>    expense of less important ones if necessary. So, dist-upgrade
>    command may remove some packages. The /etc/apt/sources.list file
>    contains a list of locations from which to retrieve desired package
>    files. See also apt_preferences(5) for a mechanism for overriding
>    the general settings for individual packages.