### PR TITLE
adding logic to push beyond the 14.04 python 2.7.6 barrier

### DIFF
--- a/runit-python/Dockerfile
+++ b/runit-python/Dockerfile
@@ -1,14 +1,21 @@
 FROM socrata/runit
 MAINTAINER Socrata <sysadmin@socrata.com>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install python python-dev python-pip
+RUN DEBIAN_FRONTEND=noninteractive
 
 # Update the Python installed version to latest
+# Recommended 3rd party PPA for newer versions of python
+# not supported by ubuntu 14.04 debian repos
+# Python 2.7.6 is too out of date for current needs
 RUN sudo add-apt-repository ppa:jonathonf/python-2.7 
-RUN sudo apt-get update
-RUN sudo apt-get upgrade --assume-yes
-RUN sudo apt-get install python2.7 --assume-yes
+RUN sudo apt-get -y update && \
+    sudo apt-get -y upgrade; \
+    sudo apt-get -y install curl \
+                            build-essential \
+                            python2.7
+
+# Install pip from source
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python
 
 # Add locale profiles and default to en_US.UTF-8
 RUN locale-gen en_US.UTF-8

--- a/runit-python/Dockerfile
+++ b/runit-python/Dockerfile
@@ -4,6 +4,12 @@ MAINTAINER Socrata <sysadmin@socrata.com>
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install python python-dev python-pip
 
+# Update the Python installed version to latest
+RUN sudo add-apt-repository ppa:jonathonf/python-2.7 
+RUN sudo apt-get update
+RUN sudo apt-get upgrade --assume-yes
+RUN sudo apt-get install python2.7 --assume-yes
+
 # Add locale profiles and default to en_US.UTF-8
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
this installs 2.7.14 (current) within the docker contiainer.  we were previously locked to the latest releast for ubuntu 14.04 which appears to be stagnant and locked to 2.7.6