### PR TITLE
Reference correct base image

### DIFF
--- a/python-bionic/2.7/Dockerfile
+++ b/python-bionic/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/base
+FROM socrata/base-bionic
 LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
python-bionic/2.7 was pointing to the `socrata/base` image, which is not `Bionic Beaver`.

Oops