### PR TITLE
Update source of base image

### DIFF
--- a/runit-bionic-python/2.7/Dockerfile
+++ b/runit-bionic-python/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata-test:runit-bionic
+FROM socrata:runit-bionic
 LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/runit-bionic-python/3.6/Dockerfile
+++ b/runit-bionic-python/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata-test:runit-bionic
+FROM socrata:runit-bionic
 LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Another testing fail.  Updating the `FROM` to point to `socrata/runit-bionic` instead of `socrata-test`, used locally.  lame.