### PR TITLE
java java java java.

### DIFF
--- a/java11-bionic/Dockerfile
+++ b/java11-bionic/Dockerfile
@@ -1,0 +1,8 @@
+FROM socrata/base-bionic
+
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get -y update && \
+        apt-get -y install openjdk-11-jdk
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/java11-bionic=""

--- a/java11-bionic/README.md
+++ b/java11-bionic/README.md
@@ -1,0 +1,17 @@
+socrata/java11-bionic
+============
+
+socrata/base-bionic image with OpenJDK *version 11* installed.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/java11-bionic` in a Dockerfile, nonetheless, you can run a java container as follows:
+
+    $ docker pull socrata/java11-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/java11-bionic bash
+
+    # Bind mount a directory into the container and build or run something
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java11-bionic javac my_app.java
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java11-bionic java -jar my_app.jar

--- a/java8-bionic/Dockerfile
+++ b/java8-bionic/Dockerfile
@@ -1,0 +1,8 @@
+FROM socrata/base-bionic
+
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get -y update && \
+        apt-get -y install openjdk-8-jdk
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/java8-bionic=""

--- a/java8-bionic/README.md
+++ b/java8-bionic/README.md
@@ -1,0 +1,17 @@
+socrata/java8-bionic
+============
+
+socrata/base-bionic image with OpenJDK *version 8* installed.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/java8-bionic` in a Dockerfile, nonetheless, you can run a java container as follows:
+
+    $ docker pull socrata/java8-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/java8-bionic bash
+
+    # Bind mount a directory into the container and build or run something
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8-bionic javac my_app.java
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8-bionic java -jar my_app.jar

--- a/java8-oracle/Dockerfile
+++ b/java8-oracle/Dockerfile
@@ -1,0 +1,13 @@
+FROM socrata/base
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:webupd8team/java && apt-get -y update && \
+  echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+  echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java8-installer && \
+  rm -rf /var/cache/oracle-jdk8-installer && \
+  rm -rf /var/lib/apt/lists/*
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/java8-oracle=""

--- a/java8-oracle/README.md
+++ b/java8-oracle/README.md
@@ -1,0 +1,19 @@
+socrata/java8-oracle
+============
+
+socrata/base image with Oracle Java *version 8* installed.  This image is deprecated,
+you should prefer the java8 image which is OpenJDK and will be supported after Oracle ends
+Java 8 support.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/java8-oracle` in a Dockerfile, nonetheless, you can run a java container as follows:
+
+    $ docker pull socrata/java8-oracle
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/java8-oracle bash
+
+    # Bind mount a directory into the container and build or run something
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8 javac my_app.java
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8 java -jar my_app.jar

--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -1,13 +1,11 @@
 FROM socrata/base
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
-  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:webupd8team/java && apt-get -y update && \
-  echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-  echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java8-installer && \
-  rm -rf /var/cache/oracle-jdk8-installer && \
-  rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get -y update && \
+        apt-get -y install software-properties-common && \
+        add-apt-repository ppa:openjdk-r/ppa && \
+        apt-get -y update && \
+        apt-get -y install openjdk-8-jdk
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/java8=""

--- a/java8/README.md
+++ b/java8/README.md
@@ -1,7 +1,7 @@
 socrata/java8
 ============
 
-socrata/base image with Oracle Java *version 8* installed.
+socrata/base image with OpenJDK *version 8* installed.
 
 ### Usage
 


### PR DESCRIPTION
- switch java8 to use openjdk8 from the openjdk-r PPA, and add
java8-oracle in case that breaks a downstream image so they have a
quick out.

- add bionic (18.04 LTS) options for java8 and 11, it supports both
of them natively even though the java 11 package is currently
actually installing java 10 there, they will update that soon.