### PR TITLE
Reset ruby shabang in clortho-get

### DIFF
--- a/base-bionic/clortho-get
+++ b/base-bionic/clortho-get
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 require 'rubygems'
 require 'aws-sdk-core'

--- a/runit-bionic/clortho-get
+++ b/runit-bionic/clortho-get
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 
 require 'rubygems'
 require 'aws-sdk-core'


### PR DESCRIPTION
Due to a swift hand of incompetence, I updated the shabang to point to
the environments ruby binary, which is incorrect for this specific file.
Returning it back to `#!/usr/bin/ruby` is the ideal solution here.