### PR TITLE
Fix broken docker build

### DIFF
--- a/py3_analysis/Dockerfile
+++ b/py3_analysis/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libblas-
 
 RUN pip install numpy==1.11.0 && \
     pip install scipy==0.17.1 && \
-    pip install scipy==0.17.1
+    pip install scikit-learn==0.17.1
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/py3_analysis=""

--- a/py3_analysis/Dockerfile
+++ b/py3_analysis/Dockerfile
@@ -2,9 +2,9 @@ FROM socrata/python3
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libblas-dev liblapack-dev
 
-RUN pip install numpy==1.11.0 \
-                scipy==0.17.1 \
-                scikit-learn==0.17.1
+RUN pip install numpy==1.11.0 && \
+    pip install scipy==0.17.1 && \
+    pip install scipy==0.17.1
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/py3_analysis=""


### PR DESCRIPTION
 This appears to be an issue with the `pip` command when installing packages where one of the packages in the list depends on another package in the list. Installing the dependencies as separate pip commands avoids the error that was preventing this from building correctly.

Tested by building locally.