### PR TITLE
Add bionic versions

### DIFF
--- a/java8-bionic/Dockerfile
+++ b/java8-bionic/Dockerfile
@@ -1,0 +1,13 @@
+FROM socrata/base-bionic
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jdk && update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+# Regenerate certs to work around bug in ca-certificates-java that results in missing Java certs
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
+RUN update-ca-certificates -f
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/java8-bionic=""

--- a/java8-bionic/README.md
+++ b/java8-bionic/README.md
@@ -1,0 +1,17 @@
+socrata/java8-bionic
+====================
+
+socrata/base-bionic image with OpenJDK *version 8* installed.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/java8-bionic` in a Dockerfile, nonetheless, you can run a java container as follows:
+
+    $ docker pull socrata/java8-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/java8-bionic bash
+
+    # Bind mount a directory into the container and build or run something
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8-bionic javac my_app.java
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/java8-bionic java -jar my_app.jar

--- a/nodejs-bionic/Dockerfile
+++ b/nodejs-bionic/Dockerfile
@@ -1,0 +1,10 @@
+FROM socrata/base-bionic
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install nodejs npm
+# NPM has a hardcoded expired cert, so disable it
+RUN npm set ca null
+RUN npm install -g n
+RUN n 6.9.1
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/nodejs-bionic=""

--- a/nodejs-bionic/README.md
+++ b/nodejs-bionic/README.md
@@ -1,0 +1,15 @@
+socrata/nodejs-bionic
+
+socrata/base-bionic image with nodejs and npm installed natively and the latest
+of io.js and node installed in userspace with n, a node package
+manager.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/nodejs-bionic` in a Dockerfile, nonetheless,
+you can get to run a node console command in the console as follows:
+
+    $ docker pull socrata/nodejs-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/nodejs-bionic node

--- a/py3_analysis-bionic/Dockerfile
+++ b/py3_analysis-bionic/Dockerfile
@@ -1,0 +1,10 @@
+FROM socrata/python3-bionic
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libblas-dev liblapack-dev && ln -s /usr/include/x86_64-linux-gnu/bits/types/__locale_t.h /usr/include/xlocale.h
+
+RUN pip install numpy==1.11.0 && \
+    pip install scipy==0.17.1 && \
+    pip install scikit-learn==0.17.1
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/py3_analysis-bionic=""

--- a/py3_analysis-bionic/README.md
+++ b/py3_analysis-bionic/README.md
@@ -1,0 +1,14 @@
+socrata/py3_analysis-bionic
+===========================
+
+socrata/python3 image with numpy, scipy and scikit installed
+Similar to the socrata/py_analysis image, but for python3.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/py3_analysis-bionic` in a Dockerfile, nonetheless, you can run a container as follows:
+
+    $ docker pull socrata/py3_analysis-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/py3_analysis-bionic python

--- a/py3_spacy-bionic/Dockerfile
+++ b/py3_spacy-bionic/Dockerfile
@@ -1,0 +1,9 @@
+FROM socrata/py3_analysis-bionic
+
+RUN pip install spacy==0.101
+# http://index.spacy.io/ is down
+# See https://github.com/explosion/spaCy/issues/1405
+# && python -m spacy.en.download
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/py3_spacy-bionic=""

--- a/py3_spacy-bionic/README.md
+++ b/py3_spacy-bionic/README.md
@@ -1,0 +1,13 @@
+socrata/py3_spacy-bionic
+========================
+
+socrata/py3_analysis-bionic with spacy-en installed
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/py3_spacy-bionic` in a Dockerfile, nonetheless, you can run a container as follows:
+
+    $ docker pull socrata/py3_spacy-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/py3_spacy-bionic python

--- a/python3-bionic/Dockerfile
+++ b/python3-bionic/Dockerfile
@@ -1,0 +1,13 @@
+FROM socrata/base-bionic
+
+RUN apt-get clean && apt-get update
+
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# install some basic goodies
+RUN apt-get purge -y python.* && apt-get -y install build-essential libssl-dev gfortran gcc g++ libbz2-dev python3 python3-pip && ln -s /usr/bin/python3 /usr/local/bin/python && ln -s /usr/bin/pip3 /usr/local/bin/pip && ln -s /usr/bin/pydoc3 /usr/local/bin/pydoc && ln -s /usr/bin/python3-config /usr/local/bin/python-config
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/python3-bionic=""

--- a/python3-bionic/README.md
+++ b/python3-bionic/README.md
@@ -1,0 +1,13 @@
+socrata/python-binoic
+=====================
+
+socrata/base-bionic image with python 3.6 and pip installed.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/python3-bionic` in a Dockerfile, nonetheless, you can run a python shell as follows:
+
+    $ docker pull socrata/python3-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/python3-bionic python

--- a/ruby-bionic/2.5.3/Dockerfile
+++ b/ruby-bionic/2.5.3/Dockerfile
@@ -1,0 +1,103 @@
+FROM socrata/base-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.5
+ENV RUBY_VERSION 2.5.3
+ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
+ENV RUBYGEMS_VERSION 2.7.4
+ENV BUNDLER_VERSION 1.17
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		bison \
+		ruby \
+		wget \
+		autoconf \
+		automake \
+		bzip2 \
+		dpkg-dev \
+		file \
+		g++ \
+		gcc \
+		imagemagick \
+		libbz2-dev \
+		libc6-dev \
+		libcurl4-openssl-dev \
+		libdb-dev \
+		libevent-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgeoip-dev \
+		libglib2.0-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		liblzma-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libncurses5-dev \
+		libncursesw5-dev \
+		libpng-dev \
+		libpq-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libwebp-dev \
+		libxml2-dev \
+		libxslt-dev \
+		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
+		zlib1g-dev \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/ruby-bionic/2.5.3=""

--- a/ruby-bionic/README.md
+++ b/ruby-bionic/README.md
@@ -1,5 +1,5 @@
 socrata/ruby-bionic
-============
+===================
 
 socrata/base-bionic image with Ruby installed
 
@@ -19,4 +19,5 @@ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/ruby-bionic:<version> ruby my
 
 ## Available versions
 
+- `socrata/ruby-bionic:2.5.3`
 - `socrata/ruby-bionic:2.6.5`

--- a/runit-java8-bionic/Dockerfile
+++ b/runit-java8-bionic/Dockerfile
@@ -1,0 +1,21 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jdk && update-java-alternatives -s java-1.8.0-openjdk-amd64 && apt-get -y install openjdk-11-jdk
+
+# Regenerate certs to work around bug in ca-certificates-java that results in missing Java certs
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
+RUN update-ca-certificates -f
+
+ENV LD_LIBRARY_PATH /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server:${LD_LIBRARY_PATH}
+ENV JAVA_TOOL_OPTIONS="-Dcom.sun.management.jmxremote.port=11114 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+
+COPY set_jmx_hostname /etc/my_init.d/set_jmx_hostname
+COPY collectd-jmx.conf /etc/collectd/conf.d/jmx.conf
+RUN sed -i -e '/^export PATH/a\' -e 'export LD_LIBARAY_PATH=/usr/lib/jvm/java-11-openjdk-amd64/lib/server' /etc/init.d/collectd
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-java8-bionic=""

--- a/runit-java8-bionic/README.md
+++ b/runit-java8-bionic/README.md
@@ -1,0 +1,56 @@
+socrata/runit-bionic
+====================
+
+Image based on phusion/baseimage-docker that establises a base set of patterns and tools for building other containers with support for multiple processes via runit. This image is packaged with OpenJDK *version 8* installed.
+
+### Features
+
+- Ubuntu 18.04 LTS. The base system.
+- A correct init process (my_init) with
+  - proper process reaping
+  - Docker Stop sends SIGTERM to the init process, which stops all processes gracefully on termination.
+- runit	replaces Ubuntu's Upstart. Used for service supervision and management
+- Fixes APT incompatibilities with Docker	See https://github.com/dotcloud/docker/issues/1024.
+- syslog-ng: A syslog daemon is necessary so that many services - including the kernel itself - can correctly log to /var/log/syslog
+- logrotate	Rotates and compresses logs on a regular basis.
+- SSH server: disabled by default
+- cron	The cron daemon must be running for cron jobs to work.
+- setuser	A tool for running a command as another user. Easier to use than su, has a smaller attack vector than sudo, and unlike chpst this tool sets $HOME correctly. Available as /sbin/setuser.
+
+See the usage section below
+
+- [envconsul](https://github.com/hashicorp/envconsul) built-in: for creating environment variables based on consul k/v pairs
+- ark-host/ark-hostname route: /etc/host route to the docker host (configurable, but defaults to the default route IP)
+
+Inside a docker container, the host’s ip and name are not available.  By invoking these scripts, we can make the container aware of its host as necessary.  They create the environment variables ARK_HOST and ARK_HOSTNAME.
+
+- env_parse:
+A tool for generating config files from [jinja](http://jinja.pocoo.org/) templates and environment variables.
+
+This script lets a service owner build configuration files that are created at run time from environment variables and a template file.  The template language is jinja and any template variables must be available as e  nvironment variables.  env_parse takes one argument, the template, and an optional argument for the output file.  If omitted, the output file is identical to the template file name with the trailing .j2 removed.
+
+### Usage
+
+Any container built on top of the socrata/runit-bionic image will default to running the whatever services are configured in /etc/service according via runit.
+
+Anything placed in /etc/my_init.d will be run on startup in lexigraphical order before runit is invoked. A non-zero return code from any of these will halt the container.
+
+### Example
+
+Assuming we build an image called awesome_sauce from a Dockerfile like this:
+
+    FROM socrata/runit-bionic
+
+    RUN mkdir /etc/service/myservice
+    COPY myservice-run /etc/service/myservice/run
+    COPY myservice-log /etc/service/myservice/log
+
+Where `run` and `log` are runit service definitions where the `run` script looks like:
+
+    #!/bin/sh
+    exec /sbin/setuser socrata my_binary
+
+and the `log` script looks like:
+
+    #!/bin/sh
+    exec svlogd -tt /var/log/myservice

--- a/runit-java8-bionic/collectd-jmx.conf
+++ b/runit-java8-bionic/collectd-jmx.conf
@@ -1,0 +1,133 @@
+LoadPlugin java
+
+<Plugin "java">
+  JVMArg "-Djava.class.path=/usr/share/collectd/java/collectd-api.jar:/usr/share/collectd/java/generic-jmx.jar"
+  JVMArg "-Dcom.sun.management.jmxremote.port=11103"
+  LoadPlugin "org.collectd.java.GenericJMX"
+
+  <Plugin "GenericJMX">
+    <MBean "memory_pool">
+      ObjectName "java.lang:type=MemoryPool,*"
+      InstancePrefix "docker.jvm.memory."
+      InstanceFrom "name"
+      <Value>
+        Type "memory"
+        Table true
+        Attribute "Usage"
+      </Value>
+    </MBean>
+    <MBean "memory">
+      ObjectName "java.lang:type=Memory"
+      InstancePrefix "docker.jvm"
+      <Value>
+        Type "memory"
+        Table true
+        Attribute "HeapMemoryUsage"
+        InstancePrefix "heap-usage."
+      </Value>
+
+      <Value>
+        Type "memory"
+        Table true
+        Attribute "NonHeapMemoryUsage"
+        InstancePrefix "nonheap-usage."
+      </Value>
+    </MBean>
+    <MBean "gc">
+      ObjectName "java.lang:type=GarbageCollector,*"
+      InstancePrefix "docker.jvm.gc."
+      InstanceFrom "name"
+      <Value>
+        Type "derive"
+        Table false
+        Attribute "CollectionCount"
+        InstancePrefix "collection-count."
+      </Value>
+      <Value>
+        Type "derive"
+        Table false
+        Attribute "CollectionTime"
+        InstancePrefix "collection-time."
+      </Value>
+    </MBean>
+    <MBean "threading">
+      ObjectName "java.lang:type=Threading"
+      InstancePrefix "docker.jvm.threading"
+      <Value>
+        Type "threads"
+        Table false
+        Attribute "ThreadCount"
+      </Value>
+    </MBean>
+
+    <MBean "custom">
+      ObjectName "metrics:name=*"
+      InstancePrefix "docker.custom."
+      InstanceFrom "name"
+      <Value>
+        Type "current"
+        Table false
+        Attribute "Count"
+        InstancePrefix "count"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "Min"
+        InstancePrefix "min"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "Max"
+        InstancePrefix "max"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "OneMinuteRate"
+        InstancePrefix "one-minute-rate"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "FifteenMinuteRate"
+        InstancePrefix "15-minute-rate"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "50thPercentile"
+        InstancePrefix "p50"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "75thPercentile"
+        InstancePrefix "p75"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "95thPercentile"
+        InstancePrefix "p95"
+      </Value>
+      <Value>
+        Type "current"
+        Table false
+        Attribute "99thPercentile"
+        InstancePrefix "p99"
+      </Value>
+    </MBean>
+
+    <Connection>
+      Host "<HOSTNAME>"
+      ServiceURL "service:jmx:rmi:///jndi/rmi://127.0.0.1:11114/jmxrmi"
+      Collect "memory_pool"
+      Collect "memory"
+      Collect "gc"
+      Collect "threading"
+      Collect "custom"
+    </Connection>
+  </Plugin>
+</Plugin>

--- a/runit-java8-bionic/set_jmx_hostname
+++ b/runit-java8-bionic/set_jmx_hostname
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+APP_NAME=`echo ${MARATHON_APP_ID}|cut -d'/' -f2`
+if [ -z ${APP_NAME} ]; then
+    APP_NAME=unknown_marathon_app
+fi
+
+sed -i 's,\(Host \)<HOSTNAME>,\1"'$APP_NAME'",' /etc/collectd/conf.d/jmx.conf

--- a/runit-nodejs-bionic/10x/Dockerfile
+++ b/runit-nodejs-bionic/10x/Dockerfile
@@ -1,0 +1,17 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# Add the NodeSource apt repository. Instructions taken from:
+# https://github.com/nodesource/distributions/blob/master/README.md#debmanual
+ENV NODE_VERSION=node_10.x
+RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $(lsb_release -s -c) main" | \
+    tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src https://deb.nodesource.com/$NODE_VERSION $(lsb_release -s -c) main" | \
+    tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y libyajl2 nodejs
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/nodejs-bionic/10x=""

--- a/runit-python-bionic/Dockerfile
+++ b/runit-python-bionic/Dockerfile
@@ -1,0 +1,15 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install python python-dev python-pip
+
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# collectd configuration
+COPY collectd.statsd.conf /etc/collectd/conf.d/statsd.conf
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-python-bionic=""

--- a/runit-python-bionic/collectd.statsd.conf
+++ b/runit-python-bionic/collectd.statsd.conf
@@ -1,0 +1,11 @@
+LoadPlugin "statsd"
+
+<Plugin statsd>
+  Host "127.0.0.1"
+  Port "8125"
+  DeleteSets     true
+  DeleteTimers   true
+  TimerPercentile 90.0
+</Plugin>
+
+

--- a/runit-ruby-bionic/2.5.3/Dockerfile
+++ b/runit-ruby-bionic/2.5.3/Dockerfile
@@ -1,0 +1,103 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.5
+ENV RUBY_VERSION 2.5.3
+ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
+ENV RUBYGEMS_VERSION 2.7.6
+ENV BUNDLER_VERSION 1.17
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		bison \
+		ruby \
+		wget \
+		autoconf \
+		automake \
+		bzip2 \
+		dpkg-dev \
+		file \
+		g++ \
+		gcc \
+		imagemagick \
+		libbz2-dev \
+		libc6-dev \
+		libcurl4-openssl-dev \
+		libdb-dev \
+		libevent-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgeoip-dev \
+		libglib2.0-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		liblzma-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libncurses5-dev \
+		libncursesw5-dev \
+		libpng-dev \
+		libpq-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libwebp-dev \
+		libxml2-dev \
+		libxslt-dev \
+		libyaml-dev \
+		make \
+		patch \
+		xz-utils \
+		zlib1g-dev \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-ruby-bionic/2.5.3=""


### PR DESCRIPTION
The scope of this change and EN-33791 is to take the trusty-based images that are in-use in marathon and produce bionic versions. Additional versions are out of scope.

Mostly copy trusty Dockerfiles.

The version of python for bionic is 3.6 so that is used for the python3-bionic image rather than installing https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz which is done for trusty.

The version of ruby for bionic is 2.5.1 but a 2.5.3 image is created to maintain bug compatibility.

The py3_spacy-bionic image does not attempt to download any model because http://index.spacy.io/ is down.

All images were tested locally with bash as an entrypoint.