### PR TITLE
NO-JIRA: Do not install gem docs with aws-sdk

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -25,7 +25,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /etc/pre-init.d
 
-RUN gem2.5 install aws-sdk-resources --pre
+RUN gem2.5 install --no-document aws-sdk-resources --pre
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/base-xenial/Dockerfile
+++ b/base-xenial/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -Lo /bin/envconsul https://github.com/hashicorp/envconsul/releases/down
 
 RUN mkdir /etc/pre-init.d
 
-RUN gem2.3 install aws-sdk-resources --pre
+RUN gem2.3 install --no-document aws-sdk-resources --pre
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -Lo /bin/envconsul https://github.com/hashicorp/envconsul/releases/down
 RUN mkdir /etc/pre-init.d
 
 # Explicitly require safe_yaml avoid "uninitialized constant Gem::SafeYAML" error due to version nightmares
-RUN ruby2.0 -r yaml -r rubygems/safe_yaml -S gem2.0 install aws-sdk-resources --pre
+RUN ruby2.0 -r yaml -r rubygems/safe_yaml -S gem2.0 install --no-document aws-sdk-resources --pre
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get -y install --no-install-recommends collectd-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem2.5 install aws-sdk-resources --pre
+RUN gem2.5 install --no-document aws-sdk-resources --pre
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir /bin/
 

--- a/runit/Dockerfile
+++ b/runit/Dockerfile
@@ -22,7 +22,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
     rm --recursive --force /var/lib/apt/lists/*
 
 # Explicitly require safe_yaml avoid "uninitialized constant Gem::SafeYAML" error due to version nightmares
-RUN ruby2.0 -r yaml -r rubygems/safe_yaml -S gem2.0 install aws-sdk-resources --pre
+RUN ruby2.0 -r yaml -r rubygems/safe_yaml -S gem2.0 install --no-document aws-sdk-resources --pre
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir /bin/
 


### PR DESCRIPTION
Prior to this change, when the `aws-sdk-resources` gem is installed when
building base images, we are not disabling the building of gem
documentation. This results in 50-100 megabytes (compressed) of documentation being added to the size of the image.

This change adds the `--no-document` option when `gem install`-ing the
`aws-sdk-resources` gem for our various base images. This saves us
50-100 megabytes (compressed) in our base images.