### PR TITLE
Add basic tools to base-bionic.

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -21,8 +21,11 @@ RUN apt-get -y update && \
           python-jinja2 \
           zip \
           ruby2.5 \
-          iproute2
-RUN rm -rf /var/lib/apt/lists/*
+          iproute2 \
+          less \
+          netcat-openbsd \
+          vim-tiny && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /etc/pre-init.d
 


### PR DESCRIPTION
While we are here, fix up the package list removal to be part of the
same run command so they don't end up in the worst of both worlds,
taking space in the layer but unusable by anything afterwards.