### PR TITLE
Correctly set collectd hostname

### DIFF
--- a/runit-bionic/set_collectd_hostname
+++ b/runit-bionic/set_collectd_hostname
@@ -3,4 +3,4 @@
 ARK_HOSTNAME=aws-private
 . /bin/set_ark_hostname
 
-sed -i 's,^\(Hostname \)<HOSTNAME>,\1'$ARK_HOSTNAME',' /etc/collectd/collectd.conf
+sed -i 's,^\(Hostname \)"<HOSTNAME>",\1"'$ARK_HOSTNAME'",' /etc/collectd/collectd.conf


### PR DESCRIPTION
Quotes were added to the hostname, causing the sed command to fail to match.

Now it matches:

`Hostname "ark-host"`