### PR TITLE
Add sudo to bionic-base for debugging.

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -y update && \
           iproute2 \
           less \
           netcat-openbsd \
+          sudo \
           vim-tiny && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
It is much friendlier for trying to debug stuff in containers than having to
use su.  It got dropped in the trusty -> bionic upgrade.