### PR TITLE
EN-40079 remove Hostname and rely on gethostname() instead

### DIFF
--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -38,7 +38,6 @@ CMD ["/sbin/my_init"]
 
 # Configure collectd
 RUN mkdir -p /etc/collectd/conf.d
-COPY set_collectd_hostname set_local_dev_hostname /etc/my_init.d/
 COPY collectd.conf /etc/collectd/collectd.conf
 COPY sv/collectd-run /etc/service/collectd/run
 

--- a/runit-bionic/collectd.conf
+++ b/runit-bionic/collectd.conf
@@ -1,8 +1,7 @@
 BaseDir "/var/lib/collectd"
 PIDFile "/run/collectd.pid"
-
-Hostname "<HOSTNAME>"
 Interval 60
+FQDNLookup false
 
 LoadPlugin logfile
 <plugin logfile>

--- a/runit-bionic/set_collectd_hostname
+++ b/runit-bionic/set_collectd_hostname
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-ARK_HOSTNAME=aws-private
-. /bin/set_ark_hostname
-
-sed -i 's,^\(Hostname \)"<HOSTNAME>",\1"'$ARK_HOSTNAME'",' /etc/collectd/collectd.conf


### PR DESCRIPTION
It seems the newer version of collectd in bionic handles hostnames differently. Simply removing `Hostname` from the config file and letting collectd call `gethostname()` seems to work. Additionally, it was determined that `FQDNLookup false` was needed.