### PR TITLE
EN-37882 Download spacy data rather than tracking via git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.tgz filter=lfs diff=lfs merge=lfs -text

--- a/py3_spacy-bionic/Dockerfile
+++ b/py3_spacy-bionic/Dockerfile
@@ -9,7 +9,8 @@ RUN pip install numpy==1.11.0 && \
     pip install spacy==0.101
 
 # NOTE: this old version of spacy no longer downloads the data associated with the library version
-ADD spacy-data-1.1.0.tgz /usr/local/lib/python3.6/dist-packages/spacy/
+RUN curl https://sa-clads-us-west-2-staging.s3-us-west-2.amazonaws.com/data/spacy-data-1.1.0.tgz -o /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz
+RUN tar -zxf /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz -C /usr/local/lib/python3.6/dist-packages/spacy/
 
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/py3_spacy-bionic=""

--- a/py3_spacy-bionic/spacy-data-1.1.0.tgz
+++ b/py3_spacy-bionic/spacy-data-1.1.0.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dca7d3f4075c05e7e1939e797667323eff73fd3d768950afe702736b92c233d6
-size 1117095882


### PR DESCRIPTION
Docker hub does not support git-lfs files. This means that previously, when docker hub built this image, it was not
recognizing the spacy data .tgz file as an LFS file and therefore not following the pointer. To work around the absence
of git lfs support, we put the data in a public S3 bucket that we download at docker build time. The tgz file contains
freely available open source code and data.

This has the added benefit that it doesn't put us over our modest Github LFS quota.

Tested locally.