### PR TITLE
EN-44356 - Added runit-ruby-bionic Dockerfiles for 2.7.2 and 3.0.0

### DIFF
--- a/runit-ruby-bionic/2.7.2/Dockerfile
+++ b/runit-ruby-bionic/2.7.2/Dockerfile
@@ -1,0 +1,102 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.2
+ENV RUBY_DOWNLOAD_SHA256 1b95ab193cc8f5b5e59d2686cb3d5dcf1ddf2a86cb6950e0b4bdaae5040ec0d6
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		bison \
+		ruby \
+		wget \
+		autoconf \
+		automake \
+		bzip2 \
+		dpkg-dev \
+		file \
+		g++ \
+		gcc \
+		imagemagick \
+		libbz2-dev \
+		libc6-dev \
+		libcurl4-openssl-dev \
+		libdb-dev \
+		libevent-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgeoip-dev \
+		libglib2.0-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		liblzma-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libncurses5-dev \
+		libncursesw5-dev \
+		libpng-dev \
+		libpq-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libwebp-dev \
+		libxml2-dev \
+		libxslt-dev \
+		libyaml-dev \
+		make \
+		patch \
+		tzdata \
+		xz-utils \
+		zlib1g-dev \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system \
+	&& gem install bundler --force \
+	&& rm -r /root/.gem/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-ruby-bionic/2.7.2=""

--- a/runit-ruby-bionic/3.0.0/Dockerfile
+++ b/runit-ruby-bionic/3.0.0/Dockerfile
@@ -1,0 +1,102 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 3.0
+ENV RUBY_VERSION 3.0.0
+ENV RUBY_DOWNLOAD_SHA256 68bfaeef027b6ccd0032504a68ae69721a70e97d921ff328c0c8836c798f6cb1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		bison \
+		ruby \
+		wget \
+		autoconf \
+		automake \
+		bzip2 \
+		dpkg-dev \
+		file \
+		g++ \
+		gcc \
+		imagemagick \
+		libbz2-dev \
+		libc6-dev \
+		libcurl4-openssl-dev \
+		libdb-dev \
+		libevent-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgeoip-dev \
+		libglib2.0-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		liblzma-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libncurses5-dev \
+		libncursesw5-dev \
+		libpng-dev \
+		libpq-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libwebp-dev \
+		libxml2-dev \
+		libxslt-dev \
+		libyaml-dev \
+		make \
+		patch \
+		tzdata \
+		xz-utils \
+		zlib1g-dev \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system \
+	&& gem install bundler --force \
+	&& rm -r /root/.gem/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-ruby-bionic/3.0.0=""

--- a/runit-ruby-bionic/README.md
+++ b/runit-ruby-bionic/README.md
@@ -1,0 +1,26 @@
+socrata/runit-ruby-bionic
+============
+
+socrata/runit-bionic image with Ruby installed
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/runit-ruby-bionic:<version>` in a Dockerfile, nonetheless, you can run a Ruby container as follows:
+
+    $ docker pull socrata/runit-ruby-bionic:<version>
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/runit-ruby-bionic:<version> bash
+
+    # Bind mount a directory into the container and build or run something
+    $ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/runit-ruby-bionic:<version> ruby my_app.rb
+
+
+### Available versions
+
+- `socrata/runit-ruby-bionic` _alias for `socrata/runit-ruby-bionic:2.7.2`_
+- `socrata/runit-ruby-bionic-2.5.3`
+- `socrata/runit-ruby-bionic-2.7.2` _alias for `socrata/runit-ruby-bionic:2.7.2`_
+- `socrata/runit-ruby-bionic:2.7.2`
+- `socrata/runit-ruby-bionic-3.0.0` _alias for `socrata/runit-ruby-bionic:3.0.0`_
+- `socrata/runit-ruby-bionic:3.0.0`


### PR DESCRIPTION
Updated runit-ruby-bionic Dockerfile for use with ruby 2.7.2 and 3.0.0, removing version pinning for gem and bundler.

Added README for runit-ruby-bionic images.