### PR TITLE
Upgrade to AWS Encryption V2 Client

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get -y update && \
 
 RUN mkdir /etc/pre-init.d
 
-RUN gem2.5 install --no-document aws-sdk-resources --pre
+RUN gem2.5 install aws-sdk-s3 -v '>= 1.76.0'
+RUN gem2.5 install --no-document aws-sdk-resources --pre -v '>= 2.11.562'
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/base-bionic/clortho-get
+++ b/base-bionic/clortho-get
@@ -54,7 +54,12 @@ end
 
 def get_file(bucket, file, key)
   begin
-    s3c = Aws::S3::Encryption::Client.new(encryption_key: key)
+    s3c = Aws::S3::EncryptionV2::Client.new(
+      encryption_key: key,
+      key_wrap_schema: :rsa_oaep_sha1, # the key_wrap_schema must be rsa_oaep_sha1 for asymmetric keys
+      content_encryption_schema: :aes_gcm_no_padding,
+      security_profile: :v2_and_legacy # to allow reading/decrypting objects encrypted by the V1 encryption client
+    )
     res = s3c.get_object(bucket: bucket,
                          key: file)
     f = File.new("/dev/shm/" + File.basename(file), 'w')


### PR DESCRIPTION
I'm not sure how to test this but it should get rid of the deprecation warning we're seeing when running `clortho-get`

```
[MAINTENANCE MODE] This version of the S3 Encryption client is currently in maintenance mode. AWS strongly recommends upgrading to the Aws::S3::EncryptionV2::Client, which provides updated data security best practices. See documentation for Aws::S3::EncryptionV2::Client.
/etc/pre-init.d/clortho-get:57:in `new'
/etc/pre-init.d/clortho-get:57:in `get_file'
/etc/pre-init.d/clortho-get:73:in `block in <main>'
/etc/pre-init.d/clortho-get:71:in `each'
/etc/pre-init.d/clortho-get:71:in `<main>'
```

Followed this: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/s3-encryption-migration.html