### PR TITLE
Updating S3 encryption client

### DIFF
--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get -y install --no-install-recommends collectd-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem2.5 install --no-document aws-sdk-resources --pre
+RUN gem2.5 install aws-sdk-s3 -v '>= 1.76.0'
+RUN gem2.5 install --no-document aws-sdk-resources --pre -v '>= 2.11.562'
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir /bin/
 

--- a/runit-bionic/clortho-get
+++ b/runit-bionic/clortho-get
@@ -46,9 +46,9 @@ end
 
 def get_file(bucket, file, key)
   begin
-    s3c = Aws::S3::Encryption::Client.new(
+    s3c = Aws::S3::EncryptionV2::Client.new(
       encryption_key: key,
-      key_wrap_schema: :rsa_oaep_sha1, # the key_wrap_schema must be rsa_oaep_sha1 for asymmetric keys
+      key_wrap_schema: :aes_gcm,
       content_encryption_schema: :aes_gcm_no_padding,
       security_profile: :v2_and_legacy # to allow reading/decrypting objects encrypted by the V1 encryption client
     )

--- a/runit-bionic/clortho-get
+++ b/runit-bionic/clortho-get
@@ -46,7 +46,12 @@ end
 
 def get_file(bucket, file, key)
   begin
-    s3c = Aws::S3::Encryption::Client.new(encryption_key: key)
+    s3c = Aws::S3::Encryption::Client.new(
+      encryption_key: key,
+      key_wrap_schema: :rsa_oaep_sha1, # the key_wrap_schema must be rsa_oaep_sha1 for asymmetric keys
+      content_encryption_schema: :aes_gcm_no_padding,
+      security_profile: :v2_and_legacy # to allow reading/decrypting objects encrypted by the V1 encryption client
+    )
     res = s3c.get_object(bucket: bucket,
                          key: file)
     f = File.new("/dev/shm/" + File.basename(file), 'w')


### PR DESCRIPTION
Copying s3 encryption client changes from base-bionic dockerfile and clortho-get to runit-bionic to make sure they don't diverge per Marc's recommendation.

https://github.com/socrata/shipyard/pull/172#issuecomment-814420921