### PR TITLE
Adding /etc/systemd/coredump.conf to base images

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -39,6 +39,9 @@ COPY ship.d /etc/ship.d/
 # Credential management bits
 COPY clortho-get /etc/pre-init.d/clortho-get
 
+# Disable core dumps for CIS benchmark
+COPY coredump.conf /etc/systemd/
+
 #Create Data Directory
 ENTRYPOINT ["/bin/ship"]
 CMD ["run"]

--- a/base-bionic/coredump.conf
+++ b/base-bionic/coredump.conf
@@ -1,0 +1,3 @@
+[Coredump]
+Storage=none
+ProcessSizeMax=0

--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -33,6 +33,9 @@ COPY env_parse set_ark_host set_ark_hostname set_metrics_dir /bin/
 # Credential management bits
 COPY clortho-get /etc/my_init.d/clortho-get
 
+# Disable core dumps for CIS benchmark
+COPY coredump.conf /etc/systemd/
+
 # Create Data Directory
 ENV METRICS_ROOT_DIR /data/metrics
 CMD ["/sbin/my_init"]

--- a/runit-bionic/coredump.conf
+++ b/runit-bionic/coredump.conf
@@ -1,0 +1,3 @@
+[Coredump]
+Storage=none
+ProcessSizeMax=0


### PR DESCRIPTION
Ensuring core dumps don't get turned on in the future if we switch to systemd for init. This also allows us to pass the CIS benchmark we're currently using.