### PR TITLE
Readding py3_spacy-bionic

### DIFF
--- a/py3_spacy-bionic/Dockerfile
+++ b/py3_spacy-bionic/Dockerfile
@@ -1,0 +1,16 @@
+FROM socrata/python3-bionic
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libblas-dev liblapack-dev && \
+    ln -s /usr/include/x86_64-linux-gnu/bits/types/__locale_t.h /usr/include/xlocale.h
+
+RUN pip install numpy==1.11.0 && \
+    pip install scipy==0.17.1 && \
+    pip install scikit-learn==0.17.1 && \
+    pip install spacy==0.101
+
+# NOTE: this old version of spacy no longer downloads the data associated with the library version
+RUN curl https://sa-clads-us-west-2-staging.s3-us-west-2.amazonaws.com/data/spacy-data-1.1.0.tgz -o /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz
+RUN tar -zxf /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz -C /usr/local/lib/python3.6/dist-packages/spacy/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/py3_spacy-bionic=""

--- a/py3_spacy-bionic/README.md
+++ b/py3_spacy-bionic/README.md
@@ -1,0 +1,13 @@
+socrata/py3_spacy-bionic
+========================
+
+socrata/py3_analysis-bionic with spacy-en installed
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/py3_spacy-bionic` in a Dockerfile, nonetheless, you can run a container as follows:
+
+    $ docker pull socrata/py3_spacy-bionic
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/py3_spacy-bionic python

--- a/py3_spacy-bionic/testing/Dockerfile
+++ b/py3_spacy-bionic/testing/Dockerfile
@@ -1,0 +1,11 @@
+FROM socrata/python3-bionic
+
+RUN python -m pip install -U pip && \
+    pip install spacy scikit-learn
+
+# NOTE: this old version of spacy no longer downloads the data associated with the library version
+RUN curl https://sa-clads-us-west-2-staging.s3-us-west-2.amazonaws.com/data/spacy-data-1.1.0.tgz -o /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz
+RUN tar -zxf /usr/local/lib/python3.6/dist-packages/spacy/spacy-data-1.1.0.tgz -C /usr/local/lib/python3.6/dist-packages/spacy/
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/py3_spacy-bionic=""


### PR DESCRIPTION
This image is used by [clads](https://github.com/socrata/clads). Readding it along with a testing tag to see if we can get it building without pinned dependencies.