### PR TITLE
Install erlang and elixir from source

### DIFF
--- a/runit-elixir/Dockerfile
+++ b/runit-elixir/Dockerfile
@@ -3,19 +3,6 @@ FROM socrata/runit-bionic
 # Set up environment
 ENV LANG C.UTF-8
 
-# Add erlang solutions repo
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install wget && \
-    wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    DEBIAN_FRONTEND=noninteractive dpkg -i erlang-solutions_1.0_all.deb
-
-# Install erlang & elixir
-# NOTE: esl-erlang & elixir are pinned to specific versions
-# Any changes to these versions should be synchronized in the
-# jenkins-workers cookbook and a new AMI should be built.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install esl-erlang=1:24.0.* elixir=1.12.*
-
 # Install Java 8. If we start using this image for things other than one app, we might want to revisit this.
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
@@ -25,6 +12,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 # Regenerate certs to work around bug in ca-certificates-java that results in missing Java certs
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
 RUN update-ca-certificates -f
+
+COPY install-elixir /tmp
+RUN /tmp/install-elixir && rm /tmp/install-elixir
 
 # Add collectd config file
 COPY collectd-socket.conf /etc/collectd/conf.d/socket.conf

--- a/runit-elixir/install-elixir
+++ b/runit-elixir/install-elixir
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -xeo pipefail
+
+tmpdir="$(mktemp -d /tmp/ex-setup.XXXXXXX)"
+
+function cleanup() {
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT
+
+cd "$tmpdir"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get -y install libncurses-dev libssl-dev
+
+curl -s -L --proto "=https" https://github.com/erlang/otp/releases/download/OTP-24.1.5/otp_src_24.1.5.tar.gz > otp_src_24.1.5.tar.gz
+curl -s -L --proto "=https" https://github.com/elixir-lang/elixir/archive/v1.12.1.tar.gz > v1.12.1.tar.gz
+
+sha256sum --check - <<EOF
+a6b28da8a6382d174bb18be781476c7ce36aae792887dc629f331b227dfad542  otp_src_24.1.5.tar.gz
+96167d614b9c483efc54bd7898c3eea4768569a77dd8892ada85d7800d5e3ea4  v1.12.1.tar.gz
+EOF
+
+tar xzf otp_src_24.1.5.tar.gz
+pushd otp_src_24.1.5
+./configure
+make
+make install
+popd
+
+tar xzf v1.12.1.tar.gz
+pushd elixir-1.12.1
+make install
+popd


### PR DESCRIPTION
* We want a bugfix that was just released, and erlang-solutions hasn't
  even gotten the _previous_ bugfix release out, so we'll just build
  erlang from source
* And as a result we need to build elixir too since it depends on
  erlang