### PR TITLE
Install set_local_dev_hostname in the runit container so local.dev.socrata.net is setup.

### DIFF
--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -29,6 +29,7 @@ RUN gem2.5 install aws-sdk-s3 -v '>= 1.76.0'
 RUN gem2.5 install --no-document aws-sdk-resources --pre -v '>= 2.11.562'
 
 COPY env_parse set_ark_host set_ark_hostname set_metrics_dir /bin/
+COPY set_local_dev_hostname /etc/my_init.d/
 
 # Credential management bits
 COPY clortho-get /etc/my_init.d/clortho-get


### PR DESCRIPTION
Things running inside containers rely on local.dev.socrata.net being remapped in the container
to point back to docker's bridge IP so services running on the host or in other containers
can be reached.

eg.

  192.168.65.2    local.dev.socrata.net

Looks like this accidentally got dropped in b6d50ca64231542cd2e57635fb4cf450933e928c.