### PR TITLE
Add python 3.8 runit image for use with updated osquery-collector

### DIFF
--- a/runit-bionic-python/3.8/Dockerfile
+++ b/runit-bionic-python/3.8/Dockerfile
@@ -1,0 +1,13 @@
+FROM socrata/runit-bionic
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install python3.8 python3.8-dev python3-pip
+
+# collectd configuration
+COPY collectd.statsd.conf /etc/collectd/conf.d/statsd.conf
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-bionic-python:3.8=""

--- a/runit-bionic-python/3.8/collectd.statsd.conf
+++ b/runit-bionic-python/3.8/collectd.statsd.conf
@@ -1,0 +1,11 @@
+LoadPlugin "statsd"
+
+<Plugin statsd>
+  Host "127.0.0.1"
+  Port "8125"
+  DeleteSets     true
+  DeleteTimers   true
+  TimerPercentile 90.0
+</Plugin>
+
+


### PR DESCRIPTION
Adds a python 3.8 runit-bionic image, pretty much just something to run osquery-collector on with a version of celery that doesn't have a high severity finding.