### PR TITLE
Add ruby 3.1 bionic images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ Build a single image from this project, with support for specific versions:
 - [`socrata/runit-ruby-bionic:2.7.x`](runit-ruby-bionic/2.7.x): `socrata/runit-bionic` version of `socrata/ruby-bionic:2.7.x`.
 - [`socrata/ruby-bionic:3.0.x`](ruby-bionic/3.0.x): `socrata/base-bionic` image with the latest point release under Ruby 3.0.
 - [`socrata/runit-ruby-bionic:3.0.x`](runit-ruby-bionic/3.0.x): `socrata/runit-bionic` version of `socrata/ruby-bionic:3.0.x`.
+- [`socrata/ruby-bionic:3.1.x`](ruby-bionic/3.1.x): `socrata/base-bionic` image with the latest point release under Ruby 3.1.
+- [`socrata/runit-ruby-bionic:3.1.x`](runit-ruby-bionic/3.1.x): `socrata/runit-bionic` version of `socrata/ruby-bionic:3.1.x`.

--- a/ruby-bionic/3.1.x/Dockerfile
+++ b/ruby-bionic/3.1.x/Dockerfile
@@ -1,0 +1,41 @@
+FROM socrata/base-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 3.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		libssl-dev \
+		libreadline-dev \
+		zlib1g-dev \
+                git \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& git clone https://github.com/rbenv/ruby-build.git /tmp/ruby-build \
+	\
+	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
+	\
+        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+	&& rm -r /tmp/ruby-build/ \
+        \
+        && if [ -n "$BUNDLER_VERSION" ] ; then \
+             gem install bundler:$BUNDLER_VERSION ;\
+           fi
+
+COPY ruby-version.rb /usr/local/bin/ruby-version.rb
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/ruby3.1.x=""

--- a/ruby-bionic/3.1.x/hooks/post_push
+++ b/ruby-bionic/3.1.x/hooks/post_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+# This file is used by Docker Hub as a post push action.
+# Other than MINOR_VERSION and RUBY_VERSION, all variables are made available
+# through Docker Hub's automated builds. 
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+if [ $DOCKER_TAG != "latest" ]; then
+    # Get the x.y.z Ruby version from the image we just built
+    RUBY_VERSION=$(docker run --entrypoint ruby-version.rb $IMAGE_NAME)
+
+    echo "Tagging $IMAGE_NAME as $DOCKER_REPO:$RUBY_VERSION and pushing."
+    docker tag $IMAGE_NAME $DOCKER_REPO:$RUBY_VERSION
+    docker push $DOCKER_REPO:$RUBY_VERSION
+else 
+    # No need to retag latest and push for this repo.
+    # latest is built and pushed separately by something that already does this.
+   echo "Not retagging latest."
+fi
+

--- a/ruby-bionic/3.1.x/ruby-version.rb
+++ b/ruby-bionic/3.1.x/ruby-version.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts RUBY_VERSION

--- a/ruby-bionic/README.md
+++ b/ruby-bionic/README.md
@@ -21,3 +21,4 @@ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/ruby-bionic:<version> ruby my
 
 - `socrata/ruby-bionic:2.7.x`
 - `socrata/ruby-bionic:3.0.x`
+- `socrata/ruby-bionic:3.1.x`

--- a/runit-ruby-bionic/3.1.x/Dockerfile
+++ b/runit-ruby-bionic/3.1.x/Dockerfile
@@ -1,0 +1,41 @@
+FROM socrata/runit-bionic
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 3.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+	        libssl-dev \
+	        libreadline-dev \
+        	zlib1g-dev \
+                git \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+        && git clone https://github.com/rbenv/ruby-build.git /tmp/ruby-build \ 
+        \
+	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
+        \
+        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && rm -r /tmp/ruby-build/ \
+        \
+        && if [ -n "$BUNDLER_VERSION" ] ; then \
+             gem install bundler:$BUNDLER_VERSION ;\
+           fi
+
+COPY ruby-version.rb /usr/local/bin/ruby-version.rb
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-ruby-bionic/3.1.x=""

--- a/runit-ruby-bionic/3.1.x/hooks/post_push
+++ b/runit-ruby-bionic/3.1.x/hooks/post_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+# This file is used by Docker Hub as a post push action.
+# Other than MINOR_VERSION and RUBY_VERSION, all variables are made available
+# through Docker Hub's automated builds. 
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+if [ $DOCKER_TAG != "latest" ]; then
+    # Get the x.y.z Ruby version from the image we just built
+    RUBY_VERSION=$(docker run --entrypoint ruby-version.rb $IMAGE_NAME)
+
+    echo "Tagging $IMAGE_NAME as $DOCKER_REPO:$RUBY_VERSION and pushing."
+    docker tag $IMAGE_NAME $DOCKER_REPO:$RUBY_VERSION
+    docker push $DOCKER_REPO:$RUBY_VERSION
+else 
+    # No need to retag latest and push for this repo.
+    # latest is built and pushed separately by something that already does this.
+   echo "Not retagging latest."
+fi
+

--- a/runit-ruby-bionic/3.1.x/ruby-version.rb
+++ b/runit-ruby-bionic/3.1.x/ruby-version.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts RUBY_VERSION

--- a/runit-ruby-bionic/README.md
+++ b/runit-ruby-bionic/README.md
@@ -21,3 +21,4 @@ Most uses of the image will be via `FROM socrata/runit-ruby-bionic:<version>` in
 - `socrata/runit-ruby-bionic` _alias for `socrata/runit-ruby-bionic:2.7.x`_
 - `socrata/runit-ruby-bionic:2.7.x`
 - `socrata/runit-ruby-bionic:3.0.x` 
+- `socrata/runit-ruby-bionic:3.1.x` 


### PR DESCRIPTION
Note these do *not* explicitly set a bundler version as 3.1 comes
with bundler 2.3.3 which is recent enough to not have any known
security vulnerabilities that require a newer verison.