### PR TITLE
Properly set some executables to be executable

### DIFF
--- a/base-focal/Dockerfile
+++ b/base-focal/Dockerfile
@@ -43,6 +43,8 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /etc/pre-init.d/clortho-get
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
+# Mark these as executable
+RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /bin/set_local_dev_hostname /etc/pre-init.d/clortho-get
 
 #Create Data Directory
 ENTRYPOINT ["/bin/ship"]

--- a/runit-focal/Dockerfile
+++ b/runit-focal/Dockerfile
@@ -36,6 +36,8 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /etc/pre-init.d/clortho-get
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
+# Mark these as executable
+RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname /etc/pre-init.d/clortho-get
 
 CMD ["/sbin/my_init"]
 


### PR DESCRIPTION
Switching from `COPY`ing some files from the local directory to `ADD`ing from an https remote caused them to lose their execute bit.