### PR TITLE
Move clortho-get to /etc/my_init.d in runit-focal image

### DIFF
--- a/runit-focal/Dockerfile
+++ b/runit-focal/Dockerfile
@@ -33,11 +33,11 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_host /
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_hostname /bin/
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_hostname /etc/my_init.d/
 # Credential management bits
-ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /etc/pre-init.d/clortho-get
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /etc/my_init.d/clortho-get
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
 # Mark these as executable
-RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname /etc/pre-init.d/clortho-get
+RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname /etc/my_init.d/clortho-get
 
 CMD ["/sbin/my_init"]
 


### PR DESCRIPTION
Because that's where my_init looks for it.  pre-init.d is used by the
"ship" script in the base image.