### PR TITLE
Restore file permissions to what they had previously been

### DIFF
--- a/base-focal/Dockerfile
+++ b/base-focal/Dockerfile
@@ -44,7 +44,7 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /e
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
 # Mark these as executable
-RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /bin/set_local_dev_hostname /etc/pre-init.d/clortho-get
+RUN chmod 755 /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /bin/set_local_dev_hostname /etc/pre-init.d/clortho-get
 
 #Create Data Directory
 ENTRYPOINT ["/bin/ship"]

--- a/runit-focal/Dockerfile
+++ b/runit-focal/Dockerfile
@@ -37,7 +37,7 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /e
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
 # Mark these as executable
-RUN chmod +x /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname /etc/my_init.d/clortho-get
+RUN chmod 755 /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname /etc/my_init.d/clortho-get
 
 CMD ["/sbin/my_init"]
 


### PR DESCRIPTION
Normal users can't read these scripts we're dumping onto the filesystem currently. This is due to the docker `ADD` command not preserving permissions since we're copying from an HTTPS location. 

Not sure if it will cause a problem, but it's definitely not the way these things were set previously.