### PR TITLE
Build erlang and elixir ourselves

### DIFF
--- a/runit-elixir-focal/Dockerfile
+++ b/runit-elixir-focal/Dockerfile
@@ -1,30 +1,43 @@
-FROM socrata/runit-focal
+FROM socrata/runit-focal AS base
 
 # Set up environment
 ENV LANG C.UTF-8
 
-# Add erlang solutions repo
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install wget && \
-    wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
-    DEBIAN_FRONTEND=noninteractive dpkg -i erlang-solutions_2.0_all.deb
-
-# Install erlang & elixir
-# NOTE: esl-erlang & elixir are pinned to specific versions
-# Any changes to these versions should be synchronized in the
-# jenkins-workers cookbook and a new AMI should be built.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install esl-erlang=1:24.1.* elixir=1.12.*
-
-# Install Java 8. If we start using this image for things other than one app, we might want to revisit this.
+# Install Java 8. If we start using this image for things other than
+# one app, we might want to revisit this.
+#
+# The update-ca-certs call is to work around a bug in
+# ca-certificates-java that results in missing Java certs
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
   DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jdk
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jdk && \
+  mkdir -p /opt && \
+  update-ca-certificates -f
 
-# Regenerate certs to work around bug in ca-certificates-java that results in missing Java certs
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
-RUN update-ca-certificates -f
+FROM base AS build
+
+RUN DEBIAN_FRONTED=noninteractive apt-get -y install wget libncurses-dev libssl-dev
+
+RUN mkdir /build /opt/erlang /opt/elixir
+WORKDIR /build
+
+RUN wget https://github.com/erlang/otp/releases/download/OTP-25.0/otp_src_25.0.tar.gz
+RUN tar xzf otp_src_25.0.tar.gz
+RUN cd otp_src_25.0 && ./configure --prefix=/opt/erlang && make && make install
+
+ENV PATH /opt/erlang/bin:$PATH
+
+RUN wget https://github.com/elixir-lang/elixir/archive/v1.12.1.tar.gz
+RUN tar xzf v1.12.1.tar.gz
+RUN cd elixir-1.12.1 && env PREFIX=/opt/elixir make install
+
+FROM base
+
+COPY --from=build /opt/ /opt/
+
+ENV PATH /opt/erlang/bin:/opt/elixir/bin:$PATH
 
 # Add collectd config file
 COPY collectd-socket.conf /etc/collectd/conf.d/socket.conf


### PR DESCRIPTION
Mainly because the erlang-solutions debs have debug info stripped,
which makes `perf` nearly useless with them.

Also upgrade to erlang 25 because that makes `perf` more useful.