### PR TITLE
Get runit-elixir building again

### DIFF
--- a/runit-elixir/Dockerfile
+++ b/runit-elixir/Dockerfile
@@ -6,15 +6,21 @@ ENV LANG C.UTF-8
 # Add erlang solutions repo
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install wget && \
-    wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    DEBIAN_FRONTEND=noninteractive dpkg -i erlang-solutions_1.0_all.deb
+    wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
+    DEBIAN_FRONTEND=noninteractive dpkg -i erlang-solutions_2.0_all.deb && \
+    rm erlang-solutions_2.0_all.deb
 
 # Install erlang & elixir
 # NOTE: esl-erlang & elixir are pinned to specific versions
 # Any changes to these versions should be synchronized in the
 # jenkins-workers cookbook and a new AMI should be built.
+# erlang repos stopped distributing elixir via apt for bionic
+# so it needs to be downloaded and installed manually
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install esl-erlang=1:24.1.* elixir=1.12.*
+    DEBIAN_FRONTEND=noninteractive apt-get -y install esl-erlang=1:25.0.* && \
+    wget https://packages.erlang-solutions.com/ubuntu/pool/elixir_1.12.2-1~ubuntu~bionic_all.deb && \
+    DEBIAN_FRONTEND=noninteractive dpkg -i elixir_1.12.2-1~ubuntu~bionic_all.deb && \
+    rm elixir_1.12.2-1~ubuntu~bionic_all.deb
 
 # Install Java 8. If we start using this image for things other than one app, we might want to revisit this.
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \


### PR DESCRIPTION
Switch to updated esl-erlang package, download and manually install elixir 1.12

Erlang solutions stopped distributing our previously used versions of the esl-erlang and elixir packages for ubuntu bionic through apt, although they still exist in their package repo.

There are some dependency issues that are tricky to work around with the previous version of esl-erlang we were using, so I bumped it to the latest.

That does satisfy the dependency requirements for elixir 1.12 that we were previously using, so it gets downloaded from the repo and installed via dpkg.

Also switching to the latest erlang-solutions installation package so that it stays up to date in the future.

Removes downloaded debs after installing to reduce clutter and image size.