### PR TITLE
EN-58985: add focal for ruby 3.0.x

### DIFF
--- a/ruby-focal/3.0.x/Dockerfile
+++ b/ruby-focal/3.0.x/Dockerfile
@@ -1,5 +1,5 @@
 FROM socrata/base-focal
-MAINTAINER Socrata <sysadmin@socrata.com>
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \

--- a/ruby-focal/3.0.x/Dockerfile
+++ b/ruby-focal/3.0.x/Dockerfile
@@ -1,0 +1,41 @@
+FROM socrata/base-focal
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 3.0
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		libssl-dev \
+		libreadline-dev \
+		zlib1g-dev \
+                git \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& git clone https://github.com/rbenv/ruby-build.git /tmp/ruby-build \
+	\
+	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
+	\
+        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+	&& rm -r /tmp/ruby-build/ \
+        \
+        && if [ -n "$BUNDLER_VERSION" ] ; then \
+             gem install bundler:$BUNDLER_VERSION ;\
+           fi
+
+COPY ruby-version.rb /usr/local/bin/ruby-version.rb
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/ruby-focal:3.0.x=""

--- a/ruby-focal/3.0.x/hooks/post_push
+++ b/ruby-focal/3.0.x/hooks/post_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+# This file is used by Docker Hub as a post push action.
+# Other than MINOR_VERSION and RUBY_VERSION, all variables are made available
+# through Docker Hub's automated builds.
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+if [ $DOCKER_TAG != "latest" ]; then
+    # Get the x.y.z Ruby version from the image we just built
+    RUBY_VERSION=$(docker run --entrypoint ruby-version.rb $IMAGE_NAME)
+
+    echo "Tagging $IMAGE_NAME as $DOCKER_REPO:$RUBY_VERSION and pushing."
+    docker tag $IMAGE_NAME $DOCKER_REPO:$RUBY_VERSION
+    docker push $DOCKER_REPO:$RUBY_VERSION
+else
+    # No need to retag latest and push for this repo.
+    # latest is built and pushed separately by something that already does this.
+   echo "Not retagging latest."
+fi
+

--- a/ruby-focal/3.0.x/ruby-version.rb
+++ b/ruby-focal/3.0.x/ruby-version.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts RUBY_VERSION

--- a/ruby-focal/README.md
+++ b/ruby-focal/README.md
@@ -19,5 +19,6 @@ docker run --rm -t -i -v `pwd`:/opt/my_app socrata/ruby-focal:<version> ruby my_
 
 ## Available versions
 
+- `socrata/ruby-focal:3.0.x`
 - `socrata/ruby-focal:3.1.x`
 - `socrata/ruby-focal:3.2.x`

--- a/runit-ruby-focal/3.0.x/Dockerfile
+++ b/runit-ruby-focal/3.0.x/Dockerfile
@@ -1,0 +1,41 @@
+FROM socrata/runit-focal
+MAINTAINER Socrata <sysadmin@socrata.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 3.0
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+	        libssl-dev \
+	        libreadline-dev \
+        	zlib1g-dev \
+                git \
+	'\
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+        && git clone https://github.com/rbenv/ruby-build.git /tmp/ruby-build \
+        \
+	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
+        \
+        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && rm -r /tmp/ruby-build/ \
+        \
+        && if [ -n "$BUNDLER_VERSION" ] ; then \
+             gem install bundler:$BUNDLER_VERSION ;\
+           fi
+
+COPY ruby-version.rb /usr/local/bin/ruby-version.rb
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-ruby-focal:3.0.x=""

--- a/runit-ruby-focal/3.0.x/Dockerfile
+++ b/runit-ruby-focal/3.0.x/Dockerfile
@@ -1,5 +1,5 @@
 FROM socrata/runit-focal
-MAINTAINER Socrata <sysadmin@socrata.com>
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \

--- a/runit-ruby-focal/3.0.x/hooks/post_push
+++ b/runit-ruby-focal/3.0.x/hooks/post_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+# This file is used by Docker Hub as a post push action.
+# Other than MINOR_VERSION and RUBY_VERSION, all variables are made available
+# through Docker Hub's automated builds.
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+if [ $DOCKER_TAG != "latest" ]; then
+    # Get the x.y.z Ruby version from the image we just built
+    RUBY_VERSION=$(docker run --entrypoint ruby-version.rb $IMAGE_NAME)
+
+    echo "Tagging $IMAGE_NAME as $DOCKER_REPO:$RUBY_VERSION and pushing."
+    docker tag $IMAGE_NAME $DOCKER_REPO:$RUBY_VERSION
+    docker push $DOCKER_REPO:$RUBY_VERSION
+else
+    # No need to retag latest and push for this repo.
+    # latest is built and pushed separately by something that already does this.
+   echo "Not retagging latest."
+fi
+

--- a/runit-ruby-focal/3.0.x/ruby-version.rb
+++ b/runit-ruby-focal/3.0.x/ruby-version.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts RUBY_VERSION

--- a/runit-ruby-focal/README.md
+++ b/runit-ruby-focal/README.md
@@ -18,5 +18,6 @@ Most uses of the image will be via `FROM socrata/runit-ruby-focal:<version>` in 
 
 ### Available versions
 
+- `socrata/runit-ruby-focal:3.0.x`
 - `socrata/runit-ruby-focal:3.1.x`
 - `socrata/runit-ruby-focal:3.2.x`


### PR DESCRIPTION
## Before

runit-ruby-focal and ruby-focal have only ruby 3.1.x and 3.2.x options.

## After

runit-ruby-focal and ruby-focal also have an option for ruby 3.0.x.
This is what is used for frontend, storyteller and elections currently.