### PR TITLE
ruby-build marked 2.7 EOL so --definitions needs to be used instead o…

### DIFF
--- a/ruby-bionic/2.7.x/Dockerfile
+++ b/ruby-bionic/2.7.x/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
 	\
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
 	\
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
         && rm -r /tmp/ruby-build/ \
         && if [ -n "$BUNDLER_VERSION" ] ; then \
           mv $(ruby -e 'puts File.join(Gem.default_dir,"specifications","default")')/*bundler*.gemspec $(ruby -e 'puts File.join(Gem.default_dir, "specifications")') \

--- a/runit-ruby-bionic/2.7.x/Dockerfile
+++ b/runit-ruby-bionic/2.7.x/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
         \
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
         \
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
         && rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \


### PR DESCRIPTION
…f -l

See https://github.com/rbenv/ruby-build/commit/269dff92b6dad247e2833c066f2587696885f1ca

According to https://www.ruby-lang.org/en/downloads/branches/ EOL is 2023-03-31 (expected)