### PR TITLE
Minor python-focal fixes

### DIFF
--- a/python-focal/Dockerfile
+++ b/python-focal/Dockerfile
@@ -7,7 +7,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # install some basic goodies
-RUN apt-get -y install build-essential libssl-dev gfortran gcc g++ libbz2-dev python-is-python3 python3-dev python3-distutils python3-pip
+RUN apt-get -y install build-essential libssl-dev gfortran gcc g++ libbz2-dev python-is-python3 python3-dev python-dev-is-python3 python3-distutils python3-pip
 
 # LABEL must be last for proper base image discoverability
-LABEL repository.socrata/python3-focal=""
+LABEL repository.socrata/python-focal=""


### PR DESCRIPTION
 - Fix repo label to just be python-focal to match 
 - Install `python-dev-is-python3` packages so that python-dev related things default to python3