### PR TITLE
runit-focal readme fix

### DIFF
--- a/runit-focal/README.md
+++ b/runit-focal/README.md
@@ -38,9 +38,9 @@ Assuming we build an image called awesome_sauce from a Dockerfile like this:
 ```Dockerfile
     FROM socrata/runit-focal
 
-    RUN mkdir /etc/sv/myservice
-    COPY myservice-run /etc/sv/myservice/run
-    COPY myservice-log /etc/sv/myservice/log/run
+    RUN mkdir /etc/service/myservice
+    COPY myservice-run /etc/service/myservice/run
+    COPY myservice-log /etc/service/myservice/log/run
 ```
 
 Where `run` and `log` are runit service definitions where the `run` script looks like:

--- a/runit-java-focal/README.md
+++ b/runit-java-focal/README.md
@@ -22,4 +22,4 @@ Most uses of the image will be via `FROM socrata/runit-java-focal:<version>` in 
 - `socrata/runit-java-focal:17`
 
 ## runit
-For more information on runit-based images, see [`socrata/runit-focal`](runit-focal).
+For more information on runit-based images, see [`socrata/runit-focal`](socrata/runit-focal).

--- a/runit-java-focal/README.md
+++ b/runit-java-focal/README.md
@@ -20,3 +20,6 @@ Most uses of the image will be via `FROM socrata/runit-java-focal:<version>` in 
 
 - `socrata/runit-java-focal:11`
 - `socrata/runit-java-focal:17`
+
+## runit
+For more information on runit-based images, see [`socrata/runit-focal`](runit-focal).

--- a/runit-java-focal/README.md
+++ b/runit-java-focal/README.md
@@ -22,4 +22,4 @@ Most uses of the image will be via `FROM socrata/runit-java-focal:<version>` in 
 - `socrata/runit-java-focal:17`
 
 ## runit
-For more information on runit-based images, see [`socrata/runit-focal`](socrata/runit-focal).
+For more information on runit-based images, see [`socrata/runit-focal`](../runit-focal).

--- a/runit-ruby-focal/README.md
+++ b/runit-ruby-focal/README.md
@@ -21,3 +21,6 @@ Most uses of the image will be via `FROM socrata/runit-ruby-focal:<version>` in 
 - `socrata/runit-ruby-focal:3.0.x`
 - `socrata/runit-ruby-focal:3.1.x`
 - `socrata/runit-ruby-focal:3.2.x`
+
+## runit
+For more information on runit-based images, see [`socrata/runit-focal`](../runit-focal).


### PR DESCRIPTION
Update runit-focal readme to clarify that runit services need to live in /etc/service, not /etc/sv in the container

Update readmes for runit-java-focal and runit-ruby-focal images to point refer back to the runit-focal readme