### PR TITLE
Fix 3.0 builds

### DIFF
--- a/ruby-bionic/3.0.x/Dockerfile
+++ b/ruby-bionic/3.0.x/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
 	\
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
 	\
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
 	&& rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \

--- a/runit-ruby-bionic/3.0.x/Dockerfile
+++ b/runit-ruby-bionic/3.0.x/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
         \
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
         \
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
         && rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \


### PR DESCRIPTION
Since ruby 3.0 is now EoL, it no no longer appears when running `ruby-build -l`. This works around that to install the latest minor version of 3.0.