### PR TITLE
Check if clortho is running in ECS, stop running clortho if so

### DIFF
--- a/base-focal-ecs/Dockerfile
+++ b/base-focal-ecs/Dockerfile
@@ -42,7 +42,7 @@ ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_host /
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_hostname /bin/
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_hostname /bin/
 # Credential management bits
-ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-get /etc/pre-init.d/clortho-get
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/clortho-ecs-safe /etc/pre-init.d/clortho-get
 # Disable core dumps for CIS benchmark
 ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
 # Mark these as executable

--- a/files/clortho-ecs-safe
+++ b/files/clortho-ecs-safe
@@ -1,5 +1,10 @@
 #!/usr/bin/ruby
 
+if ENV["AWS_EXECUTION_ENV"] == "AWS_ECS_FARGATE" then
+  puts "Skipping clortho-get because we're in ECS"
+  exit 0
+end
+
 require 'rubygems'
 require 'aws-sdk-core'
 require 'aws-sdk-resources'

--- a/files/clortho-get
+++ b/files/clortho-get
@@ -1,5 +1,10 @@
 #!/usr/bin/ruby
 
+if ENV["AWS_EXECUTION_ENV"] == "AWS_ECS_FARGATE" then
+  puts "Skipping clortho-get because we're in ECS"
+  exit 0
+end
+
 require 'rubygems'
 require 'aws-sdk-core'
 require 'aws-sdk-resources'


### PR DESCRIPTION
clortho is causing problems in images running in ECS. This adds a check to the clortho-get in /etc/pre-init.d in all images to see if the container is running inside of ECS and immediately exit if so.