### PR TITLE
python-focal:3.10

### DIFF
--- a/python-focal/3.10/Dockerfile
+++ b/python-focal/3.10/Dockerfile
@@ -1,0 +1,23 @@
+FROM socrata/base-focal
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Add locale profiles and default to en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# Add deadsnakes ppa and install 3.10
+RUN apt-get update && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get -y install python3.10 python3.10-venv python3.10-distutils python3.10-dev
+
+# Make python3.10 the default python and install pip
+RUN ln -s /usr/bin/python3.10 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.10 /usr/local/bin/python3 && \
+    python -m ensurepip && \
+    python -m pip install -U pip
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/python-focal:3.10=""

--- a/python-focal/3.10/README.md
+++ b/python-focal/3.10/README.md
@@ -1,0 +1,13 @@
+socrata/python-focal:3.10
+=====================
+
+socrata/base-focal image with python 3.10 and pip installed.
+
+### Usage
+
+Most uses of the image will be via `FROM socrata/python-focal:3.10` in a Dockerfile, nonetheless, you can run a python shell as follows:
+
+    $ docker pull socrata/python-focal:3.10
+
+    # Launch shell in the container
+    $ docker run --rm -t -i socrata/python-focal:3.10 python3.10

--- a/python-focal/3.11/Dockerfile
+++ b/python-focal/3.11/Dockerfile
@@ -13,5 +13,11 @@ RUN apt-get update && \
     apt-get update && \
     apt-get -y install python3.11 python3.11-venv python3.11-distutils python3.11-dev
 
+# Make python3.11 the default python and install pip
+RUN ln -s /usr/bin/python3.11 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
+    python -m ensurepip && \
+    python -m pip install -U pip
+
 # LABEL must be last for proper base image discoverability
 LABEL repository.socrata/python-focal:3.11=""

--- a/python-focal/3.11/README.md
+++ b/python-focal/3.11/README.md
@@ -1,4 +1,4 @@
-socrata/python-focal
+socrata/python-focal:3.11
 =====================
 
 socrata/base-focal image with python 3.11 and pip installed.

--- a/runit-python-focal/3.11/Dockerfile
+++ b/runit-python-focal/3.11/Dockerfile
@@ -20,4 +20,4 @@ RUN ln -s /usr/bin/python3.11 /usr/local/bin/python && \
 COPY collectd.statsd.conf /etc/collectd/conf.d/statsd.conf
 
 # LABEL must be last for proper base image discoverability
-LABEL repository.socrata/runit-python-focal:3.10=""
+LABEL repository.socrata/runit-python-focal:3.11=""


### PR DESCRIPTION
 - Add python-focal:3.10 image
 - Make python-focal:3.11 behave like other python base images
 - Minor corrections to python-focal:3.11 and runit-python-focal:3.11