### PR TITLE
Fix ruby 3.1.x builds

### DIFF
--- a/ruby-bionic/3.1.x/Dockerfile
+++ b/ruby-bionic/3.1.x/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex \
 	\
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
 	\
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
 	&& rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \

--- a/ruby-focal/3.1.x/Dockerfile
+++ b/ruby-focal/3.1.x/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex \
 	\
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
 	\
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
 	&& rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \

--- a/runit-ruby-bionic/3.1.x/Dockerfile
+++ b/runit-ruby-bionic/3.1.x/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex \
         \
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
         \
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
         && rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \

--- a/runit-ruby-focal/3.1.x/Dockerfile
+++ b/runit-ruby-focal/3.1.x/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex \
         \
 	&& PREFIX=/usr/local /tmp/ruby-build/install.sh \
         \
-        && ruby-build $(ruby-build -l | grep "^${RUBY_MAJOR}\.") /usr/local/ \
+        && ruby-build $(ruby-build --definitions | grep "^${RUBY_MAJOR}\." | sort --version-sort | tail -n 1) /usr/local/ \
         && rm -r /tmp/ruby-build/ \
         \
         && if [ -n "$BUNDLER_VERSION" ] ; then \


### PR DESCRIPTION
ruby-build no longer lists 3.1 versions with `-l`, switching to using `--definitions` for listing like with other deprecated versions.