### PR TITLE
Pin gems to versions that work with ruby 2.5

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -28,8 +28,15 @@ RUN apt-get -y update && \
 
 RUN mkdir /etc/pre-init.d
 
-RUN gem2.5 install aws-sdk-s3 -v '>= 1.76.0'
-RUN gem2.5 install --no-document aws-sdk-resources --pre -v '>= 2.11.562'
+# Adding --minimal-deps to these to slim down this layer
+# Adding -f to aws-sdk-resources because it kept trying to pull a version of aws-sdk-core that was incompatible with ruby 2.5
+RUN gem2.5 install --minimal-deps --no-document aws-eventstream -v '1.3.2' && \
+    gem2.5 install --minimal-deps --no-document aws-partitions -v '1.1109.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sigv4 -v '1.11.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-core -v '3.224.1' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-kms -v '1.101.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-s3 -v '1.188.0' && \
+    gem2.5 install -f --minimal-deps --no-document aws-sdk-resources -v '3.227.0'
 
 COPY env_parse set_ark_host set_ark_hostname set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -24,8 +24,15 @@ RUN apt-get -y install --no-install-recommends collectd-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem2.5 install aws-sdk-s3 -v '>= 1.76.0'
-RUN gem2.5 install --no-document aws-sdk-resources --pre -v '>= 2.11.562'
+# Adding --minimal-deps to these to slim down this layer
+# Adding -f to aws-sdk-resources because it kept trying to pull a version of aws-sdk-core that was incompatible with ruby 2.5
+RUN gem2.5 install --minimal-deps --no-document aws-eventstream -v '1.3.2' && \
+    gem2.5 install --minimal-deps --no-document aws-partitions -v '1.1109.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sigv4 -v '1.11.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-core -v '3.224.1' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-kms -v '1.101.0' && \
+    gem2.5 install --minimal-deps --no-document aws-sdk-s3 -v '1.188.0' && \
+    gem2.5 install -f --minimal-deps --no-document aws-sdk-resources -v '3.227.0'
 
 COPY env_parse set_ark_host set_ark_hostname /bin/
 COPY set_local_dev_hostname /etc/my_init.d/


### PR DESCRIPTION
base-bionic and runit-bionic stopped building due to dropped backwards compatibility in newer versions of some of these gems. 

This also combines the gem install operations into a single docker layer. Using the `--minimal-deps` option to not update already installed dependencies to slim down the final image a little bit more.

The aws-sdk-resources gem kept trying to update aws-sdk-core to a newer version even with it pinned and using `--minimal-deps` added `-f` so that it ignores the fact that it can't update core when installing resources.