### PR TITLE
Install aws-sdk-resources with bundler

### DIFF
--- a/base-bionic/Dockerfile
+++ b/base-bionic/Dockerfile
@@ -28,15 +28,10 @@ RUN apt-get -y update && \
 
 RUN mkdir /etc/pre-init.d
 
-# Adding --minimal-deps to these to slim down this layer
-# Adding -f to aws-sdk-resources because it kept trying to pull a version of aws-sdk-core that was incompatible with ruby 2.5
-RUN gem2.5 install --minimal-deps --no-document aws-eventstream -v '1.3.2' && \
-    gem2.5 install --minimal-deps --no-document aws-partitions -v '1.1109.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sigv4 -v '1.11.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-core -v '3.224.1' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-kms -v '1.101.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-s3 -v '1.188.0' && \
-    gem2.5 install -f --minimal-deps --no-document aws-sdk-resources -v '3.227.0'
+RUN gem2.5 install bundler -v '2.3.27' && \
+    bundle init && \
+    bundle add aws-sdk-resources -v '3.227.0' && \
+    rm -rf Gemfile Gemfile.lock /root/.gem /root/.bundle
 
 COPY env_parse set_ark_host set_ark_hostname set_local_dev_hostname ship /bin/
 COPY ship.d /etc/ship.d/

--- a/runit-bionic/Dockerfile
+++ b/runit-bionic/Dockerfile
@@ -24,15 +24,10 @@ RUN apt-get -y install --no-install-recommends collectd-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Adding --minimal-deps to these to slim down this layer
-# Adding -f to aws-sdk-resources because it kept trying to pull a version of aws-sdk-core that was incompatible with ruby 2.5
-RUN gem2.5 install --minimal-deps --no-document aws-eventstream -v '1.3.2' && \
-    gem2.5 install --minimal-deps --no-document aws-partitions -v '1.1109.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sigv4 -v '1.11.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-core -v '3.224.1' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-kms -v '1.101.0' && \
-    gem2.5 install --minimal-deps --no-document aws-sdk-s3 -v '1.188.0' && \
-    gem2.5 install -f --minimal-deps --no-document aws-sdk-resources -v '3.227.0'
+RUN gem2.5 install bundler -v '2.3.27' && \
+    bundle init && \
+    bundle add aws-sdk-resources -v '3.227.0' && \
+    rm -rf Gemfile Gemfile.lock /root/.gem /root/.bundle
 
 COPY env_parse set_ark_host set_ark_hostname /bin/
 COPY set_local_dev_hostname /etc/my_init.d/


### PR DESCRIPTION
Use bundler to properly install all aws-sdk-resources dependencies. The previous change I made was forcing aws-sdk-resources to ignore dependency errors.

This also significantly improves the time it takes to install the gem and its dependencies and slightly reduces the image size.