### PR TITLE
EN-80775: Security ticket to update Trino requires java 24

### DIFF
--- a/java-focal/24/Dockerfile
+++ b/java-focal/24/Dockerfile
@@ -1,0 +1,13 @@
+FROM socrata/base-focal
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
+  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-24-jdk && update-java-alternatives -s java-1.24.0-openjdk-amd64
+
+# Regenerate certs to work around bug in ca-certificates-java that results in missing Java certs
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
+RUN update-ca-certificates -f
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/java-focal:24=""


### PR DESCRIPTION
In order to update some dependencies and get on the latest version of Trino we need to update to Java 24. 

**Once this is complete and the trino update has been rolled out, we can delete the Java 23 image.**