### PR TITLE
EN-89768 - Java 25 for elixir 1.17

### DIFF
--- a/runit-elixir-jammy/1.17/Dockerfile
+++ b/runit-elixir-jammy/1.17/Dockerfile
@@ -10,9 +10,7 @@ ENV LANG C.UTF-8
 # ca-certificates-java that results in missing Java certs
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install software-properties-common && \
-  DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jdk && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-25-jdk && \
   mkdir -p /opt && \
   update-ca-certificates -f
 

--- a/runit-elixir-jammy/1.17/Dockerfile
+++ b/runit-elixir-jammy/1.17/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 # ca-certificates-java that results in missing Java certs
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-25-jdk-headless && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends openjdk-25-jdk-headless && \
   mkdir -p /opt && \
   update-ca-certificates -f
 

--- a/runit-elixir-jammy/1.17/Dockerfile
+++ b/runit-elixir-jammy/1.17/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 # ca-certificates-java that results in missing Java certs
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775775
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-25-jdk && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-25-jdk-headless && \
   mkdir -p /opt && \
   update-ca-certificates -f
 


### PR DESCRIPTION
- Switch to non-ppa version of java 25 directly from ubuntu repos
- Install headless java package to drop gui package dependencies
- Don't install recommended packages to drop some excess dependencies