### PR TITLE
EN-91450 - Flatten base images and remove ruby/aws-sdk/clortho

### DIFF
--- a/base-jammy-flattened/Dockerfile
+++ b/base-jammy-flattened/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:jammy as build
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Add a user so containers can run things as non root.  Not perfect since it is shared across containers,
+# but eventually uid namespacing will hopefully fix that.
+RUN groupadd -r socrata && useradd -m -r -g socrata socrata
+
+RUN apt-get -y update && \
+    apt-get -y upgrade; \
+    apt-get -y install \
+          build-essential \
+          locales \
+          curl \
+          dnsutils \
+          python3-jinja2 \
+          python-is-python3 \
+          zip \
+          iproute2 \
+          less \
+          netcat-openbsd \
+          sudo \
+          vim-tiny && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /etc/pre-init.d
+
+COPY ship /bin/
+COPY ship.d /etc/ship.d/
+
+# Add shared files from shipyard repo, this is done to keep these files in sync across all images
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/env_parse /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_host /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_hostname /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_hostname /bin/
+# Disable core dumps for CIS benchmark
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
+# Mark these as executable
+RUN chmod 755 /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /bin/set_local_dev_hostname
+
+# Ensure that containers and apps default to UTF-8
+RUN locale-gen en_US.UTF-8
+
+FROM scratch
+COPY --from=build / /
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG en_US.UTF-8
+
+# Default to basic no_proxy list for things that respect it such as set_ark_*
+ENV no_proxy localhost,127.0.0.1,169.254.169.254,jenkins
+
+ENTRYPOINT ["/bin/ship"]
+CMD ["run"]
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/base-jammy:flattened=""

--- a/base-jammy-flattened/Dockerfile
+++ b/base-jammy-flattened/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:jammy as build
-LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -45,7 +44,7 @@ RUN locale-gen en_US.UTF-8
 
 FROM scratch
 COPY --from=build / /
-
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8
 

--- a/base-jammy-flattened/README.md
+++ b/base-jammy-flattened/README.md
@@ -1,0 +1,51 @@
+socrata/base-jammy
+============
+
+Like the base Ubuntu image that establises a base set of patterns and
+tools for building other containers except using Ubuntu 20.04
+
+### Features
+
+- ship.d pattern: `ship` entrypoint to execute ship.d scripts
+
+See the usage section below
+
+Inside a docker container, the host’s ip and name are not available.  By invoking these scripts, we can make the container aware of its host as necessary.  They create the environment variables ARK_HOST and ARK_HOSTNAME.
+
+- env_parse:
+A tool for generating config files from [jinja](http://jinja.pocoo.org/) templates and environment variables.
+
+This script lets a service owner build configuration files that are created at run time from environment variables and a template file.  The template language is jinja and any template variables must be available as e  nvironment variables.  env_parse takes one argument, the template, and an optional argument for the output file.  If omitted, the output file is identical to the template file name with the trailing .j2 removed.
+
+### Usage
+
+Any container built on top of the socrata/base-jammy image will default to running the whatever script is dropped in `/etc/ship.d/run`. Alternatively, you can invoke any script dropped in /etc/ship.d/ or any executable in the container via the CMD argument:
+
+```bash
+    $ docker pull socrata/base-jammy
+    $ docker run --rm -t -i socrata/base-jammy [CMD]
+
+    # Examples:
+    $ docker run --rm -t -i socrata/base-jammy # runs /etc/ship.d/run in the container
+    $ docker run --rm -t -i socrata/base-jammy bash        # launch a bash shell (on PATH)
+
+    # From inside the container, launch the /etc/shipd.d/run
+    docker-host$ ship [run]
+```
+
+### Example
+
+Assuming we build an image called awesome_sauce from a Dockerfile like this:
+
+```Dockerfile
+    FROM socrata/base-jammy
+    ADD run /etc/ship.d/
+    ADD migrate /etc/ship.d/
+```
+
+where the `run` script starts a service and `migrate` is a one-off script for performing migrations.
+
+```bash
+    $ docker run --rm -t -i awesome_sauce migrate   # runs the migrations from the container
+    $ docker run --rm -t -i awesome_sauce           # starts the awesome_sauce service (via the `run` script)
+```

--- a/base-jammy-flattened/README.md
+++ b/base-jammy-flattened/README.md
@@ -1,8 +1,8 @@
-socrata/base-jammy
+socrata/base-jammy:flattened
 ============
 
 Like the base Ubuntu image that establises a base set of patterns and
-tools for building other containers except using Ubuntu 20.04
+tools for building other containers except using Ubuntu 22.04
 
 ### Features
 
@@ -22,12 +22,12 @@ This script lets a service owner build configuration files that are created at r
 Any container built on top of the socrata/base-jammy image will default to running the whatever script is dropped in `/etc/ship.d/run`. Alternatively, you can invoke any script dropped in /etc/ship.d/ or any executable in the container via the CMD argument:
 
 ```bash
-    $ docker pull socrata/base-jammy
-    $ docker run --rm -t -i socrata/base-jammy [CMD]
+    $ docker pull socrata/base-jammy:flattened
+    $ docker run --rm -t -i socrata/base-jammy:flattened [CMD]
 
     # Examples:
-    $ docker run --rm -t -i socrata/base-jammy # runs /etc/ship.d/run in the container
-    $ docker run --rm -t -i socrata/base-jammy bash        # launch a bash shell (on PATH)
+    $ docker run --rm -t -i socrata/base-jammy:flattened # runs /etc/ship.d/run in the container
+    $ docker run --rm -t -i socrata/base-jammy:flattened bash        # launch a bash shell (on PATH)
 
     # From inside the container, launch the /etc/shipd.d/run
     docker-host$ ship [run]
@@ -38,7 +38,7 @@ Any container built on top of the socrata/base-jammy image will default to runni
 Assuming we build an image called awesome_sauce from a Dockerfile like this:
 
 ```Dockerfile
-    FROM socrata/base-jammy
+    FROM socrata/base-jammy:flattened
     ADD run /etc/ship.d/
     ADD migrate /etc/ship.d/
 ```

--- a/base-jammy-flattened/ship
+++ b/base-jammy-flattened/ship
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# This script servces as a flexible docker ENTRYPOINT
+# - Add a script to /etc/ship.d/run to be the default execution
+# - Other scripts in /etc/ship.d/ can be specified as the docker command
+# - Any executable (absolute or on PATH) can also be specified as the command
+# - Adds a standard way of getting the docker host IP
+
+set -e -x -v
+
+# Try to give mesos time to fetch the logs before the container exits on error
+trap 'echo "Unexpected exit from ship, pausing to allow log collection" && sleep 20' EXIT
+
+COMMAND=${1:-run}
+shift || true
+
+# Only set up ark_host and ark_hostname if we're not in ECS
+if [ "$AWS_EXECUTION_ENV" != "AWS_ECS_FARGATE" ];then
+  source /bin/set_ark_host # in /etc/hosts
+  source /bin/set_ark_hostname
+fi
+source /bin/set_local_dev_hostname
+
+
+if [ -d /etc/pre-init.d ]; then
+    run-parts -v --exit-on-error /etc/pre-init.d
+fi
+
+# Raise the ulimit - default of 1024 is stone age
+ulimit -n 10000
+
+if [ -e /etc/ship.d/$COMMAND ]; then
+  exec /etc/ship.d/$COMMAND $@
+else
+  command -v $COMMAND >/dev/null 2>&1 || {
+      echo >&2 "Aborting. Not a valid command: $COMMAND"; exit 1;
+  }
+  exec $COMMAND $@
+fi

--- a/base-jammy-flattened/ship.d/run
+++ b/base-jammy-flattened/ship.d/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Not implemented. Add /etc/ship.d/run to the docker image to serve as the default command."
+exit 1

--- a/base-jammy/README.md
+++ b/base-jammy/README.md
@@ -2,7 +2,7 @@ socrata/base-jammy
 ============
 
 Like the base Ubuntu image that establises a base set of patterns and
-tools for building other containers except using Ubuntu 20.04
+tools for building other containers except using Ubuntu 22.04
 
 ### Features
 

--- a/runit-jammy-flattened/Dockerfile
+++ b/runit-jammy-flattened/Dockerfile
@@ -1,0 +1,63 @@
+FROM phusion/baseimage:jammy-1.0.4 as build
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Add a user so containers can run things as non root.  Not perfect since it is shared across containers,
+# but eventually uid namespacing will hopefully fix that.
+RUN groupadd -r socrata && useradd -m -r -g socrata socrata
+
+RUN apt-get -y update && \
+    apt-get -y dist-upgrade; \
+    apt-get -y install \
+          build-essential \
+          locales \
+          curl \
+          dnsutils \
+          python3-jinja2 \
+          python-is-python3 \
+          zip \
+          iproute2
+RUN apt-get -y install --no-install-recommends collectd-core && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add shared files from shipyard repo, this is done to keep these files in sync across all images
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/env_parse /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_host /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_ark_hostname /bin/
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/set_local_dev_hostname /etc/my_init.d/
+# Disable core dumps for CIS benchmark
+ADD https://raw.githubusercontent.com/socrata/shipyard/main/files/coredump.conf /etc/systemd/
+# Mark these as executable
+RUN chmod 755 /bin/env_parse /bin/set_ark_host /bin/set_ark_hostname /etc/my_init.d/set_local_dev_hostname
+
+# Ensure that containers and apps default to UTF-8
+RUN locale-gen en_US.UTF-8
+
+# Configure collectd
+RUN mkdir -p /etc/collectd/conf.d
+COPY collectd.conf /etc/collectd/collectd.conf
+COPY sv/collectd-run /etc/service/collectd/run
+
+FROM scratch
+COPY --from=build / /
+LABEL maintainer="Socrata 'sysadmin@socrata.com'"
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# Default to basic no_proxy list for things that respect it such as set_ark_*
+ENV no_proxy localhost,127.0.0.1,169.254.169.254,jenkins
+
+# Set shutdown env vars to reasonable defaults (5 min)
+ENV KILL_ALL_PROCESSES_TIMEOUT 300
+ENV KILL_PROCESS_TIMEOUT 300
+
+# Default to basic no_proxy list for things that respect it such as set_ark_*
+ENV no_proxy localhost,127.0.0.1,169.254.169.254,jenkins
+
+CMD ["/sbin/my_init"]
+
+# LABEL must be last for proper base image discoverability
+LABEL repository.socrata/runit-jammy:flattened=""

--- a/runit-jammy-flattened/README.md
+++ b/runit-jammy-flattened/README.md
@@ -1,0 +1,58 @@
+socrata/runit-jammy
+============
+
+Image based on phusion/baseimage-docker that establises a base set of patterns and tools for building other containers with support for multiple processes via runit.
+
+### Features
+
+- Ubuntu 20.04 LTS. The base system.
+- A correct init process (my_init) with
+  - proper process reaping
+  - Docker Stop sends SIGTERM to the init process, which stops all processes gracefully on termination.
+- runit	replaces Ubuntu's Upstart. Used for service supervision and management
+- syslog-ng: A syslog daemon is necessary so that many services - including the kernel itself - can correctly log to /var/log/syslog
+- logrotate	Rotates and compresses logs on a regular basis.
+- SSH server: disabled by default
+- cron	The cron daemon must be running for cron jobs to work.
+- setuser	A tool for running a command as another user. Easier to use than su, has a smaller attack vector than sudo, and unlike chpst this tool sets $HOME correctly. Available as /sbin/setuser.
+
+See the usage section below
+
+Inside a docker container, the host’s ip and name are not available.  By invoking these scripts, we can make the container aware of its host as necessary.  They create the environment variables ARK_HOST and ARK_HOSTNAME.
+
+- env_parse:
+A tool for generating config files from [jinja](http://jinja.pocoo.org/) templates and environment variables.
+
+This script lets a service owner build configuration files that are created at run time from environment variables and a template file.  The template language is jinja and any template variables must be available as environment variables.  env_parse takes one argument, the template, and an optional argument for the output file.  If omitted, the output file is identical to the template file name with the trailing .j2 removed.
+
+### Usage
+
+Any container built on top of the socrata/runit-jammy image will default to running the whatever services are configured in /etc/service according via runit.
+
+Anything placed in /etc/my_init.d will be run on startup in lexigraphical order before runit is invoked. A non-zero return code from any of these will halt the container.
+
+### Example
+
+Assuming we build an image called awesome_sauce from a Dockerfile like this:
+
+```Dockerfile
+    FROM socrata/runit-jammy
+
+    RUN mkdir /etc/service/myservice
+    COPY myservice-run /etc/service/myservice/run
+    COPY myservice-log /etc/service/myservice/log/run
+```
+
+Where `run` and `log` are runit service definitions where the `run` script looks like:
+
+```bash
+    #!/bin/sh
+    exec /sbin/setuser socrata my_binary
+```
+
+and the `log` script looks like:
+
+```bash
+    #!/bin/sh
+    exec svlogd -tt /var/log/myservice
+```

--- a/runit-jammy-flattened/README.md
+++ b/runit-jammy-flattened/README.md
@@ -1,11 +1,11 @@
-socrata/runit-jammy
+socrata/runit-jammy:flattened
 ============
 
 Image based on phusion/baseimage-docker that establises a base set of patterns and tools for building other containers with support for multiple processes via runit.
 
 ### Features
 
-- Ubuntu 20.04 LTS. The base system.
+- Ubuntu 22.04 LTS. The base system.
 - A correct init process (my_init) with
   - proper process reaping
   - Docker Stop sends SIGTERM to the init process, which stops all processes gracefully on termination.
@@ -36,7 +36,7 @@ Anything placed in /etc/my_init.d will be run on startup in lexigraphical order 
 Assuming we build an image called awesome_sauce from a Dockerfile like this:
 
 ```Dockerfile
-    FROM socrata/runit-jammy
+    FROM socrata/runit-jammy:flattened
 
     RUN mkdir /etc/service/myservice
     COPY myservice-run /etc/service/myservice/run

--- a/runit-jammy-flattened/collectd.conf
+++ b/runit-jammy-flattened/collectd.conf
@@ -1,0 +1,19 @@
+BaseDir "/var/lib/collectd"
+PIDFile "/run/collectd.pid"
+Interval 60
+FQDNLookup false
+
+LoadPlugin logfile
+<plugin logfile>
+  LogLevel info
+  File stdout
+  Timestamp true
+</plugin>
+
+LoadPlugin network
+<plugin network>
+  Server "172.17.42.1" "25826"
+</plugin>
+
+Include "/etc/collectd/conf.d/*.conf"
+

--- a/runit-jammy-flattened/sv/collectd-log
+++ b/runit-jammy-flattened/sv/collectd-log
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec svlogd -tt /var/log/collectd

--- a/runit-jammy-flattened/sv/collectd-run
+++ b/runit-jammy-flattened/sv/collectd-run
@@ -1,0 +1,3 @@
+#!/bin/sh
+sleep 10 # need collectd to start after other processes
+exec /usr/sbin/collectd -C /etc/collectd/collectd.conf -f >/dev/null

--- a/runit-jammy/README.md
+++ b/runit-jammy/README.md
@@ -5,7 +5,7 @@ Image based on phusion/baseimage-docker that establises a base set of patterns a
 
 ### Features
 
-- Ubuntu 20.04 LTS. The base system.
+- Ubuntu 22.04 LTS. The base system.
 - A correct init process (my_init) with
   - proper process reaping
   - Docker Stop sends SIGTERM to the init process, which stops all processes gracefully on termination.


### PR DESCRIPTION
Adds base-jammy:flattened and runit-jammy:flattened images that have been slimmed down and had their layers flattened for faster pull times and potentially better caching with soci